### PR TITLE
Require markdown-mode

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -5,7 +5,8 @@
 ;; Author: Alvaro Ramirez
 ;; URL: https://github.com/xenodium/chatgpt-shell
 ;; Version: 0.1
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1")
+;;                    (markdown-mode "2.5"))
 
 ;; This package is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -34,6 +35,7 @@
 (require 'map)
 (require 'cl-lib)
 (require 'comint)
+(require 'markdown-mode)
 
 (defcustom chatgpt-shell-openai-key nil
   "OpenAI key as a string or a function that loads and returns it."


### PR DESCRIPTION
This package uses `markdown-mode's `markdown-inline-code-face' and `markdown-pre-face'.  `markdown-mode' was never required, so the faces were never applied if `markdown-mode' was not required manually by the user.