### PR TITLE
Configuration `chatgpt-shell-transmitted-context-length'

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -219,11 +219,11 @@ or
          (chatgpt-shell--make-request-command-list
           (vconcat
            (last (chatgpt-shell--extract-commands-and-responses)
-                 ;; Send in pairs of prompt and completion by
-                 ;; multiplying by 2
                  (if (null chatgpt-shell-transmitted-context-length)
                      ;; If variable above is nil, send "full" context
                      2048
+                   ;; Send in pairs of prompt and completion by
+                   ;; multiplying by 2
                    (1+ (* 2 chatgpt-shell-transmitted-context-length)))))
           key)
          (lambda (response)


### PR DESCRIPTION
chatgpt-shell-transmitted-context-length controls the amount of context provided to chatGPT.

Context needs to be transmitted to the API on every request, which consumes a lot of prompt tokens as the conversation gets longer.

A value of `nil' will send "full" chat history (last 4096 messages at max), which is near enough how it was before the patch, and is the default value.

A value of 0 will not provide any context.  This is the cheapest option, but ChatGPT can only see your current prompt.  A value of 1 will send only the latest prompt-completion pair as context.  Values greater than 1 will send that amount of prompt-completion pairs to ChatGPT.