### PR TITLE
Replace curl with built-in url.el

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -38,8 +38,7 @@
 (require 'seq)
 
 (eval-when-compile
-  (require 'cl-lib)
-  (declare-function json-pretty-print "ext:json" (begin end &optional minimize)))
+  (require 'cl-lib))
 
 (defcustom chatgpt-shell-openai-key nil
   "OpenAI key as a string or a function that loads and returns it."

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -324,6 +324,7 @@ where objects are converted into alists."
          (url-request-data (concat (json-encode url-request-data) "\n"))
          (response-handler
           (lambda (status &optional cbargs)
+            (advice-remove #'url-http-create-request #'chatgpt-shell--log-request)
             (chatgpt-shell--write-output-to-log-buffer (buffer-string))
             ;; straight to the body, who cares about errors,
             ;; content-types or content-lengths
@@ -334,11 +335,9 @@ where objects are converted into alists."
     ;; Advice around `url-http-create-request' to get the raw request
     ;; message
     (advice-add #'url-http-create-request :filter-return #'chatgpt-shell--log-request)
-    ;; Is this the right way to make sure the advice is cleaned up?
-    (unwind-protect
-        (url-retrieve "https://api.openai.com/v1/chat/completions"
-                      response-handler)
-      (advice-remove #'url-http-create-request #'chatgpt-shell--log-request))))
+    (url-retrieve "https://api.openai.com/v1/chat/completions"
+                  response-handler)
+    ))
 
 (defun chatgpt-shell--log-request (request)
   (chatgpt-shell--write-output-to-log-buffer request)

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -313,6 +313,7 @@ Set SAVE-EXCURSION to prevent point from moving."
     (message "interrupted!")))
 
 (defun chatgpt-shell--eval-input (input-string)
+  "Evaluate the Lisp expression INPUT-STRING, and pretty-print the result."
   (unless chatgpt-shell--busy
     (setq chatgpt-shell--busy t)
     (cond

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -122,6 +122,8 @@ ChatGPT."
 
 (defvar chatgpt-shell--prompt-internal "ChatGPT> ")
 
+(defvar chatgpt-shell--api-endpoint "https://api.openai.com/v1/chat/completions")
+
 (defvar chatgpt-shell--current-request-id 0)
 
 (defvar chatgpt-shell--show-invisible-markers nil)
@@ -388,7 +390,7 @@ where objects are converted into alists."
     (advice-add #'url-http-create-request :filter-return #'chatgpt-shell--log-request)
     ;; implement timeouts using me
     (setq processing-buffer
-          (url-retrieve "https://api.openai.com/v1/chat/completions"
+          (url-retrieve chatgpt-shell--api-endpoint
                         #'chatgpt-shell--url-retrieve-callback))
     ;; (switch-to-buffer chatgpt-shell--url-processing-buffer)
     ))

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -429,7 +429,10 @@ request process."
           (string-trim
            (map-elt
             (map-elt
-             (seq-first (map-elt (json-parse-buffer :object-type 'alist) 'choices))
+             (seq-first (map-elt (condition-case nil
+                                     (json-parse-buffer :object-type 'alist)
+                                   (json-parse-error nil))
+                                 'choices))
              'message) 'content))))))))
 
 (defun chatgpt-shell--log-request (request)

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -407,7 +407,9 @@ URL-PROCESS-BUFFER is the buffer that is associated with the
 request process."
   (with-current-buffer url-process-buffer
     (let ((process (get-buffer-process (current-buffer))))
-      (delete-process process))))
+      (condition-case nil
+          (delete-process process)
+        (error nil)))))
 
 (defun chatgpt-shell--url-retrieve-callback (status &optional cbargs)
   ""


### PR DESCRIPTION
This commit replaces the http stack to use url.el.  A user no longer needs to have the program curl installed on their machine to use chatgpt-shell.

Logs are also changed to include the full HTTP request and response message.  This needs some more formatting, and maybe pretty-printing the body in the future.

NB: This patch just barely works, and doesn't handle HTTP errors from the server.  IMO it's more important to get this out the door sooner rather than later to avoid integration issues.