### PR TITLE
Add README snippet on using auth-sources for credentials

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,9 +23,16 @@ Load =(require 'chatgpt-shell)=
 * Set OpenAI key
 ** As function
 #+begin_src emacs-lisp
+  ;; if you are using the "pass" password manager
   (setq chatgpt-shell-openai-key
         (lambda ()
           (nth 0 (process-lines "pass" "show" "openai-key"))))
+
+  ;; or if using auth-sources, e.g., so the file ~/.authinfo has this line:
+  ;;  machine openai.com password OPENAI_KEY
+  (setq chatgpt-shell-openai-key
+        (plist-get (car (auth-source-search :host "openai.com"))
+                   :secret))
 #+end_src
 
 ** Manually


### PR DESCRIPTION
This adds an alternative snippet in the README showing how you can provide credentials in a secure way by relying on emacs's auth-sources library.

I'm not trying to clutter the beautiful simplicity of this project, so please feel free to reject this if you think it's more noise than signal. It was helpful to me so I thought I'd suggest it!