### PR TITLE
Document `auth-source-pass-get` alternative to get secrets from pass

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,6 +29,7 @@ You'll first need to get a [[https://platform.openai.com/account/api-keys][key f
   ;; if you are using the "pass" password manager
   (setq chatgpt-shell-openai-key
         (lambda ()
+          ;; (auth-source-pass-get 'secret "openai-key") ; alternative using pass support in auth-sources
           (nth 0 (process-lines "pass" "show" "openai-key"))))
 
   ;; or if using auth-sources, e.g., so the file ~/.authinfo has this line:


### PR DESCRIPTION
Personally, I prefer using
``` elisp
 (auth-source-pass-get 'secret "openai-key")
 ```
 over
 ``` elisp
 (nth 0 (process-lines "pass" "show" "openai-key")
```
`auth-source-pass-get` is included in the built-in `auth-sources` library starting from Emacs 26 and autoloaded from Emacs 27.

 The already documented `auth-source-pick-first-password`  already works with pass if you add `password-store` to `auth-sources`, therefore there's an argument that we already have documentation how to use `auth-sources`. But `auth-source-pass-get` works out-of-the-box without customizing the `auth-sources` variable and its interface is different than using `auth-source-pick-first-password` with the `password-store` backend. `auth-source-pass-get` wants the entire path to the password like `pass`, e.g. I have something similar to:
 ``` elisp
 (auth-source-pass-get 'secret "openai.com/keys/emacs")
 ```
 I found `auth-source-pick-first-password` sometimes awkward to use with `pass` because usually you give it `:host` and it searches the password file basenames (in my example just `"emacs"`) for one matching it and picks the first matching one, which I might get wrong if I have another password ending with "emacs". `auth-source-pass-get` does no fancy pattern-matching, which I prefer personally.

Still, I only put it into a comment as an alternative next to the `process-lines` method. Because strictly speaking it's in the heading how to do things without `auth-sources`, but it's in the `auth-sources.el` library which still needs to be loaded then. Even though it doesn't use the backends in the `auth-sources` variable.