### PR TITLE
Drop superfluous "chatgpt" from several symbol names in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,7 +74,7 @@ Alternatively, use either =M-x chatgpt-shell-clear-buffer= or =M-x comint-clear-
 Save with =M-x shell-maker-save-session-transcript= and restore with =M-x chatgpt-shell-restore-session-from-transcript=.
 
 * Streaming
-=(setq chatgpt-shell-chatgpt-streaming t)= enables/disables streaming.
+=(setq chatgpt-shell-streaming t)= enables/disables streaming.
 
 * Explain code in region
 
@@ -110,21 +110,21 @@ Load =(require 'ob-dall-e-shell)= and invoke =(ob-dall-e-shell-setup)=.
 
 * Customizations
 
-|---------------------------------------+---------------------------------------------------------------------------|
-| chatgpt-shell-chatgpt-default-prompts | List of prompts to choose from in the minibuffer.                         |
-| chatgpt-shell-model-version           | The used ChatGPT OpenAI model.                                            |
-| chatgpt-shell-chatgpt-streaming       | Whether or not to stream ChatGPT responses (experimental).                |
-| chatgpt-shell-chatgpt-system-prompt   | The system message helps set the behavior of the assistant.               |
-| chatgpt-shell-language-mapping        | Maps external language names to Emacs names.                              |
-| chatgpt-shell-model-temperature       | What sampling temperature to use, between 0 and 2, or nil.                |
-| chatgpt-shell-openai-key              | OpenAI key as a string or a function that loads and returns it.           |
-| chatgpt-shell-request-timeout         | How long to wait for a request to time out.                               |
-| chatgpt-shell-display-function        | Function to display new shell. Can be set to `display-buffer' or similar. |
-| chatgpt-shell-read-string-function    | Function to read strings from user.                                       |
-| chatgpt-shell-on-response-function    | Function to automatically execute after last command output.              |
-| dall-e-shell-openai-key               | OpenAI key as a string or a function that loads and returns it.           |
-| dall-e-image-size                     | The default size of the requested image as a string.                      |
-| dall-e-model-version                  | The used DALL-E OpenAI model.                                             |
+|------------------------------------+---------------------------------------------------------------------------|
+| chatgpt-shell-default-prompts      | List of prompts to choose from in the minibuffer.                         |
+| chatgpt-shell-model-version        | The used ChatGPT OpenAI model.                                            |
+| chatgpt-shell-streaming            | Whether or not to stream ChatGPT responses (experimental).                |
+| chatgpt-shell-system-prompt        | The system message helps set the behavior of the assistant.               |
+| chatgpt-shell-language-mapping     | Maps external language names to Emacs names.                              |
+| chatgpt-shell-model-temperature    | What sampling temperature to use, between 0 and 2, or nil.                |
+| chatgpt-shell-openai-key           | OpenAI key as a string or a function that loads and returns it.           |
+| chatgpt-shell-request-timeout      | How long to wait for a request to time out.                               |
+| chatgpt-shell-display-function     | Function to display new shell. Can be set to `display-buffer' or similar. |
+| chatgpt-shell-read-string-function | Function to read strings from user.                                       |
+| chatgpt-shell-on-response-function | Function to automatically execute after last command output.              |
+| dall-e-shell-openai-key            | OpenAI key as a string or a function that loads and returns it.           |
+| dall-e-image-size                  | The default size of the requested image as a string.                      |
+| dall-e-model-version               | The used DALL-E OpenAI model.                                             |
 
 There are more. Browse via =M-x set-variable=
 
@@ -133,7 +133,7 @@ There are more. Browse via =M-x set-variable=
 |----------------------------------------------------+--------------------------------------------------------|
 | dall-e-shell                                       | Start a DALL-E shell.                                  |
 | chatgpt-shell                                      | Start a ChatGPT shell.                                 |
-| chatgpt-shell-chatgpt-prompt                       | Make a ChatGPT request from the minibuffer.            |
+| chatgpt-shell-prompt                               | Make a ChatGPT request from the minibuffer.            |
 | chatgpt-shell-describe-code                        | Describe code from region using ChatGPT.               |
 | chatgpt-shell-eshell-summarize-last-command-output | Ask ChatGPT to summarize the last command output.      |
 | chatgpt-shell-eshell-whats-wrong-with-last-command | Ask ChatGPT what's wrong with the last eshell command. |


### PR DESCRIPTION
Simple typofix for several function and variable names.

BTW it would be nice to document what "streaming" means exactly in the context of chatgpt.