### PR TITLE
Make ChatGPT API customize option from two parts.

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,12 +29,16 @@ As of now, only =chatgpt-shell= is available on MELPA.
 If using [[https://github.com/jwiegley/use-package][use-package]], you can install with =:ensure t=.
 
 #+begin_src emacs-lisp :lexical no
-  (use-package chatgpt-shell
-    :ensure t
-    :custom
-    (chatgpt-shell-openai-key
-     (lambda ()
-       (auth-source-pass-get 'secret "openai-key"))))
+(use-package chatgpt-shell
+  :ensure t
+  :custom
+  ((chatgpt-shell-openai-key
+    (lambda ()
+      (auth-source-pass-get 'secret "openai-key")))
+   ;; If you use ChatGPT through proxy service for example: "https://api.chatgpt.domain.com".
+   (chatgpt-shell-api-url-base
+    "https://api.chatgpt.domain.com")
+   ))
 #+end_src
 
 Read on for setting your OpenAI key in other ways.
@@ -141,6 +145,24 @@ Streaming is enabled by default. =(setq chatgpt-shell-chatgpt-streaming nil)= to
 | chatgpt-shell-request-timeout            | How long to wait for a request to time out.                                    |
 
 There are more. Browse via =M-x set-variable=
+
+** ChatGPT through proxy service
+
+If you use ChatGPT through proxy service "https://api.chatgpt.domain.com", set options like bellowing:
+
+#+begin_src emacs-lisp :lexical no
+(use-package chatgpt-shell
+  :ensure t
+  :custom
+  ((chatgpt-shell-api-url-base "https://api.chatgpt.domain.com")
+   (chatgpt-shell-openai-key
+    (lambda ()
+      ;; here the openai-key should be the proxy service key.
+      (auth-source-pass-get 'secret "openai-key")))))
+#+end_src
+
+If your proxy service API path is not OpenAI ChatGPT default path like "=/v1/chat/completions=", then
+you can customize option ~chatgpt-shell-api-url-path~.
 
 ** =chatgpt-shell-display-function= (with custom function)
 

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -212,7 +212,30 @@ ChatGPT."
                  (const :tag "Not set" nil))
   :group 'chatgpt-shell)
 
-(defvar chatgpt-shell--url "https://api.openai.com/v1/chat/completions")
+(defcustom chatgpt-shell-api-url-base "https://api.openai.com"
+  "The base domain part of complete API request entry point.
+If you use ChatGPT through proxy service instead of official API URL.
+Change this option."
+  :type 'string
+  :safe #'stringp
+  :group 'chatgpt-shell)
+
+(defcustom chatgpt-shell-api-url-path "/v1/chat/completions"
+  "The path part of complete API request entry point.
+Not suggested to modify this custom option.
+Option for future API entry upgrade."
+  :type 'string
+  :safe #'stringp
+  :group 'chatgpt-shell)
+
+(defcustom chatgpt-shell-api-url
+  (concat chatgpt-shell-api-url-base chatgpt-shell-api-url-path)
+  "The complete API request entry point.
+If you use ChatGPT through proxy service instead of official API URL.
+Suggest to customize option `chatgpt-shell-api-url-base'."
+  :type 'string
+  :safe #'stringp
+  :group 'chatgpt-shell)
 
 (defvar chatgpt-shell--config
   (make-shell-maker-config
@@ -746,7 +769,7 @@ For example:
 
 (defun chatgpt-shell--make-curl-request-command-list (request-data)
   "Build ChatGPT curl command list using REQUEST-DATA."
-  (append (list "curl" chatgpt-shell--url)
+  (append (list "curl" chatgpt-shell-api-url)
           chatgpt-shell-additional-curl-options
           (list "--fail-with-body"
                 "--no-progress-meter"


### PR DESCRIPTION
Two parts constructed URL string to suit more situations.

Fix #73 