### PR TITLE
Upgrade model versions

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -185,9 +185,9 @@ Can be used compile or run source block at point."
 
 (defcustom chatgpt-shell-model-versions
   '("gpt-3.5-turbo"
-    "gpt-3.5-turbo-0301"
+    "gpt-3.5-turbo-0613"
     "gpt-4"
-    "gpt-4-0314")
+    "gpt-4-0613")
   "The list of ChatGPT OpenAI models to swap from.
 
 The list of models supported by /v1/chat/completions endpoint is
@@ -1409,12 +1409,12 @@ For example:
          (context-length original-length))
     (cond
      ((or (string= model "gpt-3.5-turbo")
-          (string= model "gpt-3.5-turbo-0301"))
+          (string= model "gpt-3.5-turbo-0613"))
       (setq tokens-per-message 4
             ;; https://platform.openai.com/docs/models/gpt-3-5
             max-tokens 4096))
      ((or (string= model "gpt-4")
-          (string= model "gpt-4-0314"))
+          (string= model "gpt-4-0613"))
       (setq tokens-per-message 3
             ;; https://platform.openai.com/docs/models/gpt-4
             max-tokens 8192)))


### PR DESCRIPTION
## About

- OpenAI announced new version of ChatGPT models: https://openai.com/blog/function-calling-and-other-api-updates
- And some current versions are deprecated:
    - `gpt-3.5-turbo-0301`
    - `gpt-4-0314`
- So, we need to upgrade model versions: 
    - `gpt-3.5-turbo-0613`
    - `gpt-4-0613`

## Note

- I am currently unable to access GPT-4 by API
    - So I could not test `gpt-4-0613` model by `chatgpt-shell`