### PR TITLE
Changes some references to `shell-maker-mode` to `chatgpt-shell-mode`

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1765,7 +1765,7 @@ If no LENGTH set, use 2048."
     2048))
 
 (defun chatgpt-shell-view-at-point ()
-  "View prompt and putput at point in a separate buffer."
+  "View prompt and output at point in a separate buffer."
   (interactive)
   (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -814,7 +814,7 @@ With prefix IGNORE-ITEM, do not use interrupted item in context."
 
 Could be a prompt or a source block."
   (interactive)
-  (unless (eq major-mode 'shell-maker-mode)
+  (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
   (let ((prompt-pos (save-excursion
                       (when (comint-next-prompt (- 1))
@@ -835,7 +835,7 @@ Could be a prompt or a source block."
 
 Could be a prompt or a source block."
   (interactive)
-  (unless (eq major-mode 'shell-maker-mode)
+  (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
   (let ((prompt-pos (save-excursion
                       (when (comint-next-prompt 1)
@@ -1464,7 +1464,7 @@ For example:
 
 Very much EXPERIMENTAL."
   (interactive)
-  (unless (eq major-mode 'shell-maker-mode)
+  (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
   (let* ((path (read-file-name "Restore from: " nil nil t))
          (prompt-regexp (shell-maker-prompt-regexp shell-maker-config))
@@ -1767,7 +1767,7 @@ If no LENGTH set, use 2048."
 (defun chatgpt-shell-view-at-point ()
   "View prompt and putput at point in a separate buffer."
   (interactive)
-  (unless (eq major-mode 'shell-maker-mode)
+  (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
   (let ((prompt-pos (save-excursion
                       (goto-char (process-mark


### PR DESCRIPTION
Addresses a few of the chatgpt-shell functions returning errors about not being in a shell because the major mode was changed to `chatgpt-shell-mode` and they expected `shell-maker-mode`