### PR TITLE
Allow for multiline input

### DIFF
--- a/shell-maker.el
+++ b/shell-maker.el
@@ -141,6 +141,8 @@ Specify NO-FOCUS if started shell should not be focused."
          (define-key ,(shell-maker-major-mode-map config)
            [remap comint-send-input] 'shell-maker-submit)
          (define-key ,(shell-maker-major-mode-map config)
+           (kbd "S-<return>") #'newline)
+         (define-key ,(shell-maker-major-mode-map config)
            [remap comint-interrupt-subjob] 'shell-maker-interrupt)
          (define-key ,(shell-maker-major-mode-map config)
            (kbd "C-x C-s") 'shell-maker-save-session-transcript)


### PR DESCRIPTION
I sometimes need to type multiple line input, but it seems that there is no simple way to do it. (Please correct me if I'm wrong)

This PR simply adds a default keybinding for `newline`. I believe `S-<return>` is somewhat standard for inserting newline when `<return>` was occupied.