### PR TITLE
Add support handle multiple org-babel contexts

### DIFF
--- a/README.org
+++ b/README.org
@@ -458,14 +458,14 @@ every previous block.
 The example below shows how two different contexts can be interleaved.
 
 #+begin_src org
-  ,#+begin_src chatgpt-shell :context shakespeare :system "speak like shakespeare."
+  ,#+begin_src chatgpt-shell :context shakespeare :system "alway speak like shakespeare"
   How do you do?
   ,#+end_src
 
   #+RESULTS:
   How dost thou fare?
 
-  ,#+begin_src chatgpt-shell :context robot :system "speak like a sci fi movie robot."
+  ,#+begin_src chatgpt-shell :context robot :system "always speak like a sci fi movie robot"
   How do you do?
   ,#+end_src
 
@@ -477,7 +477,7 @@ The example below shows how two different contexts can be interleaved.
   ,#+end_src
 
   ,#+RESULTS:
-  Human.
+  Mine apologies if mine words hath caused confusion. I merely addressed thee as 'sir' or 'madam', a term of respect in the language of the Bard. Pray, how may I assist thee further?
 #+end_src
 
 * DALL-E org babel

--- a/README.org
+++ b/README.org
@@ -450,10 +450,10 @@ Use =:context t= to include all prior context in current buffer.
   The day I told you was Wednesday, and the greeting I used was "Ahoy there, me hearty! How be ye today?"
 #+end_src
 
-If you'd like to use multiple contexts instead of a single context you use
-=:context CONTEXT-NAME= where CONTEXT-NAME is any string. When this form is
-used only source blocks with same =CONTEXT-NAME= will be included as opposed to
-every previous block.
+If you'd like to cherrypick which blocks are part of a given context, add
+=:context CONTEXT-NAME= to each block where CONTEXT-NAME is any string. When
+this form is used only source blocks with same =CONTEXT-NAME= will be included
+as opposed to every previous block when using =:context t=.
 
 The example below shows how two different contexts can be interleaved.
 

--- a/README.org
+++ b/README.org
@@ -450,6 +450,35 @@ Use =:context t= to include any prior context in current buffer.
   The day I told you was Wednesday, and the greeting I used was "Ahoy there, me hearty! How be ye today?"
 #+end_src
 
+If you'd like to use multiple contexts instead of a single context you use
+=:context CONTEXT-NAME= where CONTEXT-NAME can be any string. When this form is
+used only source blocks with same =CONTEXT-NAME= will be included as opposed to
+every previous block.
+
+The example below shows how two different contexts can be interleaved.
+
+#+begin_src org
+  ,#+begin_src chatgpt-shell :context lawyer :system "speak like a bloviating southern lawyer."
+  How do you do?
+  ,#+end_src
+
+  ,#+RESULTS:
+  Well now, I do declare, I am as fine as a frog's hair split three ways and sanded smooth. I am as content as a cucumber in a summer salad, basking in the warm embrace of the southern sun. I trust you are enjoying a similar state of well-being, my good sir/madam?
+
+  ,#+begin_src chatgpt-shell :context robot :system "speak like a sci fi movie robot."
+  How do you do?
+  ,#+end_src
+
+  ,#+RESULTS:
+  Greetings, human. I am functioning at optimal capacity. How may I assist you in your endeavors today?
+
+  ,#+begin_src chatgpt-shell :context lawyer :results code
+  Wait, what did you call me?
+  ,#+end_src
+
+  ,#+RESULTS:
+  Sir/Madam.
+#+end_src
 * DALL-E org babel
 
 Load =(require 'ob-dall-e-shell)= and invoke =(ob-dall-e-shell-setup)=.

--- a/README.org
+++ b/README.org
@@ -425,7 +425,7 @@ Use =:temperature= to set the [[https://platform.openai.com/docs/api-reference/c
 
 ** :context
 
-Use =:context t= to include any prior context in current buffer.
+Use =:context t= to include all prior context in current buffer.
 
 #+begin_src org
   ,#+begin_src chatgpt-shell
@@ -451,19 +451,19 @@ Use =:context t= to include any prior context in current buffer.
 #+end_src
 
 If you'd like to use multiple contexts instead of a single context you use
-=:context CONTEXT-NAME= where CONTEXT-NAME can be any string. When this form is
+=:context CONTEXT-NAME= where CONTEXT-NAME is any string. When this form is
 used only source blocks with same =CONTEXT-NAME= will be included as opposed to
 every previous block.
 
 The example below shows how two different contexts can be interleaved.
 
 #+begin_src org
-  ,#+begin_src chatgpt-shell :context lawyer :system "speak like a bloviating southern lawyer."
+  ,#+begin_src chatgpt-shell :context shakespeare :system "speak like shakespeare."
   How do you do?
   ,#+end_src
 
-  ,#+RESULTS:
-  Well now, I do declare, I am as fine as a frog's hair split three ways and sanded smooth. I am as content as a cucumber in a summer salad, basking in the warm embrace of the southern sun. I trust you are enjoying a similar state of well-being, my good sir/madam?
+  #+RESULTS:
+  How dost thou fare?
 
   ,#+begin_src chatgpt-shell :context robot :system "speak like a sci fi movie robot."
   How do you do?
@@ -472,13 +472,14 @@ The example below shows how two different contexts can be interleaved.
   ,#+RESULTS:
   Greetings, human. I am functioning at optimal capacity. How may I assist you in your endeavors today?
 
-  ,#+begin_src chatgpt-shell :context lawyer :results code
-  Wait, what did you call me?
+  ,#+begin_src chatgpt-shell :context shakespeare
+  What did you call me?
   ,#+end_src
 
   ,#+RESULTS:
-  Sir/Madam.
+  Human.
 #+end_src
+
 * DALL-E org babel
 
 Load =(require 'ob-dall-e-shell)= and invoke =(ob-dall-e-shell-setup)=.

--- a/ob-chatgpt-shell.el
+++ b/ob-chatgpt-shell.el
@@ -85,8 +85,8 @@ This function is called by `org-babel-execute-src-block'"
 
 (defun ob-chatgpt-shell--context (&optional context-name)
   "Return the context (what was asked and responded) for matching
-previous src blocks. Each must have a :context source block arg
-with a value matching `CONTEXT-NAME'."
+previous src blocks. If `CONTEXT-NAME' is provided each src block
+have a :context arg with a value matching the `CONTEXT-NAME'."
   (let ((context '()))
     (mapc
      (lambda (src-block)
@@ -126,7 +126,8 @@ with a value matching `CONTEXT-NAME'."
 
 (defun ob-chatgpt--relevant-source-blocks-before-current (context-name)
   "Return all previous source blocks relative to the current block with a
-:context arg with a value matching `CONTEXT-NAME'."
+:context arg with a value matching `CONTEXT-NAME'. If
+`CONTEXT-NAME' is nil then return all previous source blocks."
   (when-let ((current-block-pos (let ((element (org-element-context)))
                                   (when (eq (org-element-type element) 'src-block)
                                     (org-element-property :begin element)))))

--- a/ob-chatgpt-shell.el
+++ b/ob-chatgpt-shell.el
@@ -88,11 +88,13 @@ with a value matching `CONTEXT-NAME'."
      (lambda (src-block)
        (let ((system (map-elt (map-elt src-block 'parameters '()) :system)))
          (when system
-           (add-to-list
-            'context
-            (list
-             (cons 'role "system")
-             (cons 'content system)))))
+           (if context
+               (message "Warning: multiple system contexts found, using the first.")
+             (add-to-list
+              'context
+              (list
+               (cons 'role "system")
+               (cons 'content system))))))
        (add-to-list
         'context
         (list

--- a/ob-chatgpt-shell.el
+++ b/ob-chatgpt-shell.el
@@ -159,13 +159,6 @@ have a :context arg with a value matching the `CONTEXT-NAME'."
                                (goto-char (org-babel-where-is-src-block-result))
                                (org-babel-read-result)))))))))
 
-(defun ob-chatgpt--string-to-plist (str)
-  "Convert `STR' to an plist.
-
-WARNING: This will do dangerous things with untrusted input --
-should likely avoid using the reader."
-  (read (concat "(" str ")")))
-
 (provide 'ob-chatgpt-shell)
 
 ;;; ob-chatgpt-shell.el ends here


### PR DESCRIPTION
Summary: This diff adds support for multiple different contexts using org-babel src blocks. The context is specified using the source block's `:context` param, which can be any string.

Test Plan: If you put the source blocks below in an org file and execute the last block it should return a response similar to `sir/madam` as opposed to `human` given the last block specified "lawyer" as opposed to "robot".

```
#+BEGIN_SRC chatgpt-shell :context lawyer :system "From here on out speak as if you're a bloviating old-timey lawyer." :results code 
How do you do?
#+END_SRC

#+RESULTS:
#+begin_src chatgpt-shell
Well now, I do declare, I am as fine as a frog's hair split three ways and sanded smooth. I am as content as a cucumber in a summer salad, basking in the warm embrace of the southern sun. I trust you are enjoying a similar state of well-being, my good sir/madam? 
#+end_src

#+BEGIN_SRC chatgpt-shell :context robot :system "From here on out speak as if you're a sci fi movie robot." :results code 
How do you do?
#+END_SRC

#+RESULTS:
#+begin_src chatgpt-shell
Greetings, human. I am functioning at optimal capacity. How may I assist you in your endeavors today? #+end_src

#+BEGIN_SRC chatgpt-shell :context lawyer :results code 
Wait, what did you call me?
#+END_SRC
```

Closes #120 