### PR TITLE
moves macros above defuns that call them

### DIFF
--- a/shell-maker.el
+++ b/shell-maker.el
@@ -120,6 +120,19 @@ For example:
 
 (defvar-local shell-maker--buffer-name-override nil)
 
+(defmacro shell-maker--with-buffer-if (wrap buffer &rest body)
+  "If WRAP, wrap BODY `with-current-buffer' BUFFER."
+  `(if ,wrap
+       (with-current-buffer ,buffer ,@body)
+     ,@body))
+
+(defmacro shell-maker--with-temp-buffer-if (wrap &rest body)
+  "If WRAP, wrap BODY `with-temp-buffer'."
+  (declare (indent 1) (debug t))
+  `(if ,wrap
+       (with-temp-buffer ,@body)
+     ,@body))
+
 (defun shell-maker-start (config &optional no-focus welcome-function new-session buffer-name)
   "Start a shell with CONFIG.
 
@@ -1220,19 +1233,6 @@ If KEEP-IN-HISTORY, don't mark to ignore it."
                         (lambda (_)
                           (funcall action)))
     (buffer-string)))
-
-(defmacro shell-maker--with-buffer-if (wrap buffer &rest body)
-  "If WRAP, wrap BODY `with-current-buffer' BUFFER."
-  `(if ,wrap
-       (with-current-buffer ,buffer ,@body)
-     ,@body))
-
-(defmacro shell-maker--with-temp-buffer-if (wrap &rest body)
-  "If WRAP, wrap BODY `with-temp-buffer'."
-  (declare (indent 1) (debug t))
-  `(if ,wrap
-       (with-temp-buffer ,@body)
-     ,@body))
 
 (provide 'shell-maker)
 


### PR DESCRIPTION
See #122 

Addresses an issue where invoking `chatgpt-shell` resulted in error `shell-maker-start: Invalid function: shell-maker--with-temp-buffer-if`

Moving the new macros to the top of the file solves the issue. I think this is related to byte-compilation:

> In order for compilation of macro calls to work, the macros must already be defined in Lisp when the calls to them are compiled. The compiler has a special feature to help you do this: if a file being compiled contains a defmacro form, the macro is defined temporarily for the rest of the compilation of that file.

https://www.gnu.org/software/emacs/manual/html_node/elisp/Compiling-Macros.html