### PR TITLE
Add UTF-8 support to HTTP requests and responses

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1594,7 +1594,7 @@ For example:
           (list "--fail-with-body"
                 "--no-progress-meter"
                 "-m" (number-to-string chatgpt-shell-request-timeout)
-                "-H" "Content-Type: application/json"
+                "-H" "Content-Type: application/json; charset=utf-8"
                 "-H" (format "Authorization: Bearer %s"
                              (cond ((stringp chatgpt-shell-openai-key)
                                     chatgpt-shell-openai-key)

--- a/dall-e-shell.el
+++ b/dall-e-shell.el
@@ -263,7 +263,7 @@ ERROR-CALLBACK otherwise."
         "--fail-with-body"
         "--no-progress-meter"
         "-m" (number-to-string dall-e-shell-request-timeout)
-        "-H" "Content-Type: application/json"
+        "-H" "Content-Type: application/json; charset=utf-8"
         "-H" (format "Authorization: Bearer %s"
                      (cond ((stringp dall-e-shell-openai-key)
                             dall-e-shell-openai-key)


### PR DESCRIPTION
Without UTF-8 support, you cannot effectively use this interface with languages such as German, French, and others. The responses are not properly displayed when there are characters with diacritical marks involved (such as German umlauts).