### PR TITLE
Update chatgpt-shell-model-versions to include 16K context for GPT-3.5 Turbo

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -201,6 +201,8 @@ Can be used compile or run source block at point."
 (defcustom chatgpt-shell-model-versions
   '("gpt-3.5-turbo"
     "gpt-3.5-turbo-0613"
+    "gpt-3.5-turbo-16k"
+    "gpt-3.5-turbo-16k-0613"
     "gpt-4"
     "gpt-4-0613")
   "The list of ChatGPT OpenAI models to swap from.


### PR DESCRIPTION
Still keeping the 4K Context version since it's double the price to use the higher context window version. Ideally the shell would switch to the higher context version automatically.

https://openai.com/pricing