### PR TITLE
Update the customization type of `chatgpt-shell-language-mapping`

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -172,7 +172,8 @@ For example:
 
                   lowercase      Emacs mode (without -mode)
 Objective-C -> (\"objective-c\" . \"objc\")"
-  :type '(repeat (cons string string))
+  :type '(alist :key-type (string :tag "Language Name/Alias")
+                :value-type (string :tag "Mode Name (without -mode)"))
   :group 'chatgpt-shell)
 
 (defcustom chatgpt-shell-babel-headers '(("dot" . ((:file . "<temp-file>.png")))


### PR DESCRIPTION
This improves the ability to edit this using customize

This is a first commit for #167.

That said, it may make more sense to consider a type as follows:
```elisp
'(alist :key-type regexp
        :value-type function)
```
and use regular expression matching (thus only one entry for Objective C) to get the mode directly.