### PR TITLE
Add default directory for restoring transcripts

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -2053,7 +2053,7 @@ Very much EXPERIMENTAL."
   (interactive)
   (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
-  (let* ((path (read-file-name "Restore from: " nil nil t))
+  (let* ((path (read-file-name "Restore from: " (file-name-as-directory shell-maker-transcript-default-path) nil t))
          (prompt-regexp (shell-maker-prompt-regexp shell-maker--config))
          (history (with-temp-buffer
                     (insert-file-contents path)

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -2053,7 +2053,9 @@ Very much EXPERIMENTAL."
   (interactive)
   (unless (eq major-mode 'chatgpt-shell-mode)
     (user-error "Not in a shell"))
-  (let* ((path (read-file-name "Restore from: " (file-name-as-directory shell-maker-transcript-default-path) nil t))
+  (let* ((dir (and shell-maker-transcript-default-path
+                   (file-name-as-directory shell-maker-transcript-default-path)))
+         (path (read-file-name "Restore from: " dir nil t))
          (prompt-regexp (shell-maker-prompt-regexp shell-maker--config))
          (history (with-temp-buffer
                     (insert-file-contents path)


### PR DESCRIPTION
The function `chatgpt-shell-restore-session-from-transcript` does not current specify the directory when reading the filename of the transcript to restore. This can be a bit inconvenient for users as they will usually have to navigate to `shell-maker-transcript-default-path` manually each time. This PR fixes that issue.