### PR TITLE
alias chatgpt-shell-historty-path to the new shell-maker variable

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -156,7 +156,7 @@ For example:
 
 (defvaralias 'chatgpt-shell-logging 'shell-maker-logging)
 
-(defvaralias 'chatgpt-shell-history-path 'shell-maker-history-path)
+(defvaralias 'chatgpt-shell-history-path 'shell-maker-root-path)
 
 (defalias 'chatgpt-shell-save-session-transcript #'shell-maker-save-session-transcript)
 


### PR DESCRIPTION
commit 03afa73 updated `shell-maker-history-path` to `shell-maker-root-path`