### PR TITLE
Fix/Rework display of system prompt

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -613,7 +613,7 @@ Set NEW-SESSION to start a separate new session."
 (defun chatgpt-shell--shrink-system-prompt (prompt)
   "Shrink PROMPT."
   (if (consp prompt)
-      (car prompt)
+      (chatgpt-shell--shrink-system-prompt (car prompt))
     (if (> (length (string-trim prompt)) 15)
         (format "%s..."
                 (substring (string-trim prompt) 0 12))

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -614,9 +614,9 @@ Set NEW-SESSION to start a separate new session."
   "Shrink PROMPT."
   (if (consp prompt)
       (car prompt)
-    (if (> (length (string-trim prompt)) 6)
+    (if (> (length (string-trim prompt)) 15)
         (format "%s..."
-                (substring (string-trim prompt) 0 15))
+                (substring (string-trim prompt) 0 12))
       (string-trim prompt))))
 
 (defun chatgpt-shell--shell-info ()


### PR DESCRIPTION
Hi! I ran into tow smallish issues in `chatgpt-shell--shrink-system-prompt` the other day and thought it'd attempt to fix them real quick.

(1) The first issue shows itself only when `chatgpt-shell-system-prompt` is set to a string value, like this:

```elisp
(setq chatgpt-shell-system-prompt "General")
```

If the system prompt's name happens to be > 6 chars and < 15 chars like in the example above, I get this error when starting a shell:

```
Args out of range: "General", 0, 15
```

That's because `(substring "General" 0 15)` can't take 15 chars out of a string of length 7. I believe this is caused by a mismatch of the string length limits used in `chatgpt-shell--shrink-system-prompt`.

(2) The second issue I found is that system prompt names are not shrunk at all if `chatgpt-shell-system-prompt` is set to an integer value.

The MR fixes both issues -- let me know what you think!

Finally, thanks so much for your work on this package, I really appreciate it! 💛 