### PR TITLE
Explicitly specify UTF-8 encoding for temporary file in Windows

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1935,6 +1935,8 @@ For example:
   "Build ChatGPT curl command list using REQUEST-DATA."
   (let ((json-path (chatgpt-shell--json-request-file)))
     (with-temp-file json-path
+      (when (eq system-type 'windows-nt)
+        (setq-local buffer-file-coding-system 'utf-8))
       (insert (shell-maker--json-encode request-data)))
     (append (list "curl" (chatgpt-shell--api-url))
             chatgpt-shell-additional-curl-options


### PR DESCRIPTION
The temporary buffer created in Windows with Chinese locale uses `chinese-gbk-dos` by default. The chatgpt may complain that _there's an encoding issue_ since chinese characters encoded in `chinese-gbk-dos` and sent in UTF-8 will be transcoded into \uFFFD.

```
ChatGPT(4o/General)> 你好
It seems like there's an encoding issue with your message. Could you please clarify or rephrase your query?

ChatGPT(4o/General)> please send back the previous message and its unicode
Sure, here's your previous message along with its unicode representation:

### Original Message:
���

### Unicode Representation:
\uFFFD\uFFFD\uFFFD

It looks like the characters are not displaying correctly, which is why they appear as replacement characters (�). If you have a specific message or question, please try sending it again.
```

This patch explicitly specify UTF-8 as the encoding system of temporary buffer in Windows to avoid such issue. PTAL.