### PR TITLE
Draft: Reset the file path after clean the buffer

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -606,7 +606,7 @@ Set NEW-SESSION to start a separate new session."
     shell-buffer))
 
 (defun chatgpt-shell-clear-buffer ()
-  "Vlean the current shell buffer."
+  "Clean the current shell buffer."
   (interactive)
   (comint-clear-buffer)
   (shell-maker--reset-file-path)

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -542,8 +542,6 @@ or
                                    output)
        output))))
 
-(defalias 'chatgpt-shell-clear-buffer #'comint-clear-buffer)
-
 (defalias 'chatgpt-shell-explain-code #'chatgpt-shell-describe-code)
 
 ;; Aliasing enables editing as text in babel.
@@ -606,6 +604,13 @@ Set NEW-SESSION to start a separate new session."
     (define-key chatgpt-shell-mode-map (kbd "C-c C-e")
       #'chatgpt-shell-prompt-compose)
     shell-buffer))
+
+(defun chatgpt-shell-clear-buffer ()
+  "Vlean the current shell buffer."
+  (interactive)
+  (comint-clear-buffer)
+  (shell-maker--reset-file-path)
+  )
 
 (defun chatgpt-shell--shrink-model-version (model-version)
   "Shrink MODEL-VERSION.  gpt-3.5-turbo -> 3.5t."

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -608,9 +608,9 @@ Set NEW-SESSION to start a separate new session."
 (defun chatgpt-shell-clear-buffer ()
   "Clean the current shell buffer."
   (interactive)
-  (comint-clear-buffer)
-  (shell-maker--reset-file-path)
-  )
+  (when shell-maker-forget-file-after-clean
+    (setq shell-maker--file nil))
+  (comint-clear-buffer))
 
 (defun chatgpt-shell--shrink-model-version (model-version)
   "Shrink MODEL-VERSION.  gpt-3.5-turbo -> 3.5t."

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -606,7 +606,7 @@ Set NEW-SESSION to start a separate new session."
     shell-buffer))
 
 (defun chatgpt-shell-clear-buffer ()
-  "Clean the current shell buffer."
+  "Clear the current shell buffer."
   (interactive)
   (when shell-maker-forget-file-after-clean
     (setq shell-maker--file nil))

--- a/shell-maker.el
+++ b/shell-maker.el
@@ -97,13 +97,10 @@ For example:
   :type 'directory
   :group 'shell-maker)
 
-(defcustom shell-maker-if-file-path-reset-after-clean nil
-  "Tell the shell-maker-save-session-transcript reset file path or not.
-
-Values: \\'reset, nil (default)"
-  :type 'symbol
-  :group 'shell-maker
-  )
+(defcustom shell-maker-forget-file-after-clean nil
+  "Tell the `shell-maker-save-session-transcript' reset file path or not."
+  :type 'boolean
+  :group 'shell-maker)
 
 (defvar-local shell-maker--input nil)
 
@@ -931,14 +928,6 @@ NO-ANNOUNCEMENT skips announcing response when in background."
 (defun shell-maker--process nil
   "Get shell buffer process."
   (get-buffer-process (shell-maker-buffer shell-maker--config)))
-
-(defun shell-maker--reset-file-path ()
-  "Reset the `shell-maker--file`.
-
-Depend on shell-maker-if-file-path-reset-after-clean."
-  (pcase shell-maker-if-file-path-reset-after-clean
-    ('reset (setq shell-maker--file nil))
-    (_)))
 
 (defun shell-maker-save-session-transcript ()
   "Save shell transcript to file.

--- a/shell-maker.el
+++ b/shell-maker.el
@@ -97,6 +97,14 @@ For example:
   :type 'directory
   :group 'shell-maker)
 
+(defcustom shell-maker-if-file-path-reset-after-clean nil
+  "Tell the shell-maker-save-session-transcript reset file path or not.
+
+Values: \\'reset, nil (default)"
+  :type 'symbol
+  :group 'shell-maker
+  )
+
 (defvar-local shell-maker--input nil)
 
 (defvar-local shell-maker--current-request-id 0)
@@ -923,6 +931,14 @@ NO-ANNOUNCEMENT skips announcing response when in background."
 (defun shell-maker--process nil
   "Get shell buffer process."
   (get-buffer-process (shell-maker-buffer shell-maker--config)))
+
+(defun shell-maker--reset-file-path ()
+  "Reset the `shell-maker--file`.
+
+Depend on shell-maker-if-file-path-reset-after-clean."
+  (pcase shell-maker-if-file-path-reset-after-clean
+    ('reset (setq shell-maker--file nil))
+    (_)))
 
 (defun shell-maker-save-session-transcript ()
   "Save shell transcript to file.

--- a/shell-maker.el
+++ b/shell-maker.el
@@ -98,7 +98,7 @@ For example:
   :group 'shell-maker)
 
 (defcustom shell-maker-forget-file-after-clean nil
-  "Tell the `shell-maker-save-session-transcript' reset file path or not."
+  "If non-nil, reset file path after clear command."
   :type 'boolean
   :group 'shell-maker)
 


### PR DESCRIPTION
Try to implement the issue #227 .

After `(setf shell-maker-if-file-path-reset-after-clean 'reset)` and manually binding the `("C-c M-o" . chatgpt-shell-clear-buffer)`. It will reset the `shell-maker--file`to `nil` after I clean the buffer. So I can save the new conversation in new file. 

**Feel free to change it if it isn't match the design of **owner.**

