### PR TITLE
Initial implementation of chatgpt-shell-ollama-load-models

### DIFF
--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -109,6 +109,8 @@ VALIDATE-COMMAND handler."
                          :output)))
          (token-width (chatgpt-shell-ollama--parse-token-width
                        (map-elt (map-elt data 'details) 'quantization_level)))
+         ;; The context length key depends on the name of the model. For qwen2,
+         ;; it's at: model_info -> qwen2.context_length.
          (context-window (cdr (cl-find-if (lambda (cell)
                                             (string-suffix-p "context_length" (symbol-name (car cell))))
                                           (map-elt data 'model_info)))))

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -120,9 +120,10 @@ VALIDATE-COMMAND handler."
 (cl-defun chatgpt-shell-ollama-load-models (&key override)
   "Query ollama for the locally installed models and add them to
 `chatgpt-shell-models' unless a model with the same name is
-already present. If OVERRIDE is non-nil (interactively with a
-prefix argument), remove all ollama models from
-`chatgpt-shell-models' before inserting locally installed models."
+already present. By default, replace the ollama models in
+`chatgpt-shell-models' locally installed ollama models. When
+OVERRIDE is non-nil (interactively with a prefix argument),
+replace all models with locally installed ollama models."
   (interactive (list :override current-prefix-arg))
   (let* ((ollama-predicate (lambda (model)
                              (string= (map-elt model :provider) "Ollama")))
@@ -130,8 +131,8 @@ prefix argument), remove all ollama models from
          ;; be placed in the same part of the list.
          (ollama-index (or (cl-position-if ollama-predicate chatgpt-shell-models)
                            (length chatgpt-shell-models))))
-    (when override
-      (setq chatgpt-shell-models (cl-remove-if ollama-predicate chatgpt-shell-models)))
+    (setq chatgpt-shell-models (and (not override)
+                                    (cl-remove-if ollama-predicate chatgpt-shell-models)))
     (let* ((existing-ollama-versions (mapcar (lambda (model)
                                                (map-elt model :version))
                                              (cl-remove-if-not ollama-predicate

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -144,7 +144,10 @@ replace all models with locally installed ollama models."
       (setq chatgpt-shell-models
             (append (seq-take chatgpt-shell-models ollama-index)
                     new-ollama-models
-                    (seq-drop chatgpt-shell-models ollama-index))))))
+                    (seq-drop chatgpt-shell-models ollama-index)))
+      (message "Added %d ollama model(s); kept %d existing ollama model(s)"
+               (length new-ollama-models)
+               (length existing-ollama-versions)))))
 
 (cl-defun chatgpt-shell-ollama--handle-ollama-command (&key model command context shell settings)
   "Handle Ollama shell COMMAND (prompt) using MODEL, CONTEXT, SHELL, and SETTINGS."

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -98,8 +98,8 @@ VALIDATE-COMMAND handler."
                    'models)))
 
 (defun chatgpt-shell-ollama--parse-token-width (quantization)
-  (string-match "^[FQ]\\([1-9][0-9]*\\)" quantization)
-  (string-to-number (match-string 1 quantization)))
+  (when (string-match "^[FQ]\\([1-9][0-9]*\\)" quantization)
+    (string-to-number (match-string 1 quantization))))
 
 (defun chatgpt-shell-ollama--fetch-model (version)
   (let* ((data (shell-maker--json-parse-string

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -100,7 +100,7 @@ VALIDATE-COMMAND handler."
   (string-match "^[FQ]\\([1-9][0-9]*\\)" quantization)
   (string-to-number (match-string 1 quantization)))
 
-(defun chatgpt-shell-ollama--make-model (version)
+(defun chatgpt-shell-ollama--fetch-model (version)
   (let* ((data (shell-maker--json-parse-string
                 (map-elt (shell-maker-make-http-request
                           :async nil
@@ -142,7 +142,7 @@ replace all models with locally installed ollama models."
            (new-ollama-versions (cl-remove-if (lambda (version)
                                                 (member version existing-ollama-versions))
                                               (chatgpt-shell-ollama--fetch-model-versions)))
-           (new-ollama-models (mapcar #'chatgpt-shell-ollama--make-model new-ollama-versions)))
+           (new-ollama-models (mapcar #'chatgpt-shell-ollama--fetch-model new-ollama-versions)))
       (setq chatgpt-shell-models
             (append (seq-take chatgpt-shell-models ollama-index)
                     new-ollama-models

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -33,6 +33,8 @@
 (require 'seq)
 (require 'subr-x)
 
+;; Muffle warning about free variable.
+(defvar chatgpt-shell-models)
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 (declare-function chatgpt-shell-openai--user-assistant-messages "chatgpt-shell-openai")
@@ -65,6 +67,16 @@ VALIDATE-COMMAND handler."
     (:filter . chatgpt-shell-ollama--extract-ollama-response)
     (:payload . chatgpt-shell-ollama-make-payload)
     (:url . chatgpt-shell-ollama--make-url)))
+
+(defcustom chatgpt-shell-ollama-api-url-base "http://localhost:11434"
+  "Ollama API's base URL.
+
+API url = base + path.
+
+If you use Ollama through a proxy service, change the URL base."
+  :type 'string
+  :safe #'stringp
+  :group 'chatgpt-shell)
 
 (defun chatgpt-shell-ollama-models ()
   "Build a list of Ollama LLM models available."
@@ -167,16 +179,6 @@ replace all models with locally installed ollama models."
                                                 :settings settings)
    :filter #'chatgpt-shell-ollama--extract-ollama-response
    :shell shell))
-
-(defcustom chatgpt-shell-ollama-api-url-base "http://localhost:11434"
-"Ollama API's base URL.
-
-API url = base + path.
-
-If you use Ollama through a proxy service, change the URL base."
-  :type 'string
-  :safe #'stringp
-  :group 'chatgpt-shell)
 
 (cl-defun chatgpt-shell-ollama--make-url (&key _model _settings)
   "Create the API URL using MODEL and SETTINGS."

--- a/chatgpt-shell-ollama.el
+++ b/chatgpt-shell-ollama.el
@@ -27,6 +27,7 @@
 
 (eval-when-compile
   (require 'cl-lib))
+(require 'let-alist)
 (require 'shell-maker)
 (require 'map)
 (require 'seq)
@@ -107,8 +108,9 @@ VALIDATE-COMMAND handler."
                           :url (concat chatgpt-shell-ollama-api-url-base "/api/show")
                           :data `((model . ,version)))
                          :output)))
-         (token-width (chatgpt-shell-ollama--parse-token-width
-                       (map-elt (map-elt data 'details) 'quantization_level)))
+         (token-width (let-alist data
+                        (chatgpt-shell-ollama--parse-token-width
+                         .details.quantization_level)))
          ;; The context length key depends on the name of the model. For qwen2,
          ;; it's at: model_info -> qwen2.context_length.
          (context-window (cdr (cl-find-if (lambda (cell)


### PR DESCRIPTION
This is a basic implementation of chatgpt-shell-ollama-load-models. I've tested it lightly and it seems to work at least for my ollama setup.