### PR TITLE
Openrouter

### DIFF
--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base 'chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and
@@ -285,10 +285,7 @@ or
     (funcall (map-elt shell :finish-output) nil))
   (shell-maker-make-http-request
    :async t
-   :url (concat (or (map-elt model :url-base)
-                    (error "Model :url-base not found"))
-                (or (map-elt model :path)
-                    (error "Model :path not found")))
+   :url (chatgpt-shell-openai--make-url :model model)
    :proxy chatgpt-shell-proxy
    :data (chatgpt-shell-openai-make-chatgpt-request-data
           :prompt command

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -263,7 +263,7 @@ or
 
 (cl-defun chatgpt-shell-openai--make-payload (&key model context settings)
   "Create the API payload using MODEL CONTEXT and SETTINGS."
-  (apply
+  (funcall
    #'chatgpt-shell-openai-make-chatgpt-request-data
    :system-prompt (map-elt settings :system-prompt)
    :context context

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base 'chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base 'chatgpt-shell-api-url-base) (path "/v1/chat/completions") (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base 'chatgpt-shell-api-url-base) (path "/v1/chat/completions") (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base 'chatgpt-shell-api-url-base) (path "/v1/chat/completions") (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) (filter #'chatgpt-shell-openai--filter-output) other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and
@@ -56,7 +56,7 @@ VALIDATE-COMMAND handler."
     (:token-width . ,token-width)
     (:context-window . ,context-window)
     (:handler . ,handler)
-    (:filter . chatgpt-shell-openai--filter-output)
+    (:filter . ,filter)
     (:payload . chatgpt-shell-openai--make-payload)
     (:headers . ,headers)
     (:url . chatgpt-shell-openai--make-url)

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and
@@ -55,7 +55,7 @@ VALIDATE-COMMAND handler."
     (:path . "/v1/chat/completions")
     (:token-width . ,token-width)
     (:context-window . ,context-window)
-    (:handler . chatgpt-shell-openai--handle-chatgpt-command)
+    (:handler . ,handler)
     (:filter . chatgpt-shell-openai--filter-output)
     (:payload . chatgpt-shell-openai--make-payload)
     (:headers . chatgpt-shell-openai--make-headers)
@@ -278,7 +278,7 @@ or
    :streaming (map-elt settings :streaming)
    :other-params (map-elt model :other-params)))
 
-(cl-defun chatgpt-shell-openai--handle-chatgpt-command (&key model command context shell settings)
+(cl-defun chatgpt-shell-openai--handle-chatgpt-command (&key model command context shell settings (key #'chatgpt-shell-openai-key))
   "Handle ChatGPT COMMAND (prompt) using MODEL, CONTEXT, SHELL, and SETTINGS."
   (unless (chatgpt-shell-openai-key)
     (funcall (map-elt shell :write-output) "Your chatgpt-shell-openai-key is missing")
@@ -298,7 +298,7 @@ or
           :streaming (map-elt settings :streaming)
           :other-params (map-elt model :other-params))
    :headers (list "Content-Type: application/json; charset=utf-8"
-                  (format "Authorization: Bearer %s" (chatgpt-shell-openai-key)))
+                  (format "Authorization: Bearer %s" (funcall key)))
    :filter #'chatgpt-shell-openai--filter-output
    :shell shell))
 

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -272,10 +272,10 @@ or
    :streaming (map-elt settings :streaming)
    :other-params (map-elt model :other-params)))
 
-(cl-defun chatgpt-shell-openai--handle-chatgpt-command (&key model command context shell settings (key #'chatgpt-shell-openai-key) (filter #'chatgpt-shell-openai--filter-output))
+(cl-defun chatgpt-shell-openai--handle-chatgpt-command (&key model command context shell settings (key #'chatgpt-shell-openai-key) (filter #'chatgpt-shell-openai--filter-output) (missing-key-msg "Your chatgpt-shell-openai-key is missing"))
   "Handle ChatGPT COMMAND (prompt) using MODEL, CONTEXT, SHELL, and SETTINGS."
   (unless (funcall key)
-    (funcall (map-elt shell :write-output) "Your chatgpt-shell-openai-key is missing")
+    (funcall (map-elt shell :write-output) missing-key-msg)
     (funcall (map-elt shell :finish-output) nil))
   (shell-maker-make-http-request
    :async t

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and
@@ -60,7 +60,7 @@ VALIDATE-COMMAND handler."
     (:payload . chatgpt-shell-openai--make-payload)
     (:headers . chatgpt-shell-openai--make-headers)
     (:url . chatgpt-shell-openai--make-url)
-    (:key . chatgpt-shell-openai-key)
+    (:key . ,key)
     (:url-base . ,url-base)
     (:validate-command . ,(or validate-command 'chatgpt-shell-openai--validate-command))
     (:other-params . ,other-params)))

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -280,12 +280,13 @@ or
 
 (cl-defun chatgpt-shell-openai--handle-chatgpt-command (&key model command context shell settings (key #'chatgpt-shell-openai-key))
   "Handle ChatGPT COMMAND (prompt) using MODEL, CONTEXT, SHELL, and SETTINGS."
-  (unless (chatgpt-shell-openai-key)
+  (unless (funcall key)
     (funcall (map-elt shell :write-output) "Your chatgpt-shell-openai-key is missing")
     (funcall (map-elt shell :finish-output) nil))
   (shell-maker-make-http-request
    :async t
-   :url (concat chatgpt-shell-api-url-base
+   :url (concat (or (map-elt model :url-base)
+                    (error "Model :url-base not found"))
                 (or (map-elt model :path)
                     (error "Model :path not found")))
    :proxy chatgpt-shell-proxy

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -33,7 +33,7 @@
 (declare-function chatgpt-shell-crop-context "chatgpt-shell")
 (declare-function chatgpt-shell--make-chatgpt-url "chatgpt-shell")
 
-(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
+(cl-defun chatgpt-shell-openai-make-model (&key version short-version token-width context-window validate-command (headers #'chatgpt-shell-openai--make-headers) (key chatgpt-shell-openai-key) (url-base chatgpt-shell-api-url-base) (provider "OpenAI") (label "ChatGPT") (handler #'chatgpt-shell-openai--handle-chatgpt-command) other-params)
   "Create an OpenAI model.
 
 Set VERSION, SHORT-VERSION, TOKEN-WIDTH, CONTEXT-WINDOW and
@@ -58,7 +58,7 @@ VALIDATE-COMMAND handler."
     (:handler . ,handler)
     (:filter . chatgpt-shell-openai--filter-output)
     (:payload . chatgpt-shell-openai--make-payload)
-    (:headers . chatgpt-shell-openai--make-headers)
+    (:headers . ,headers)
     (:url . chatgpt-shell-openai--make-url)
     (:key . ,key)
     (:url-base . ,url-base)
@@ -251,10 +251,10 @@ Otherwise:
           (or (map-elt model :path)
               (error "Model :path not found"))))
 
-(cl-defun chatgpt-shell-openai--make-headers (&key _model _settings)
+(cl-defun chatgpt-shell-openai--make-headers (&key _model _settings (key #'chatgpt-shell-openai-key))
   "Create the API headers."
   (list "Content-Type: application/json; charset=utf-8"
-        (format "Authorization: Bearer %s" (chatgpt-shell-openai-key))))
+        (format "Authorization: Bearer %s" (funcall key))))
 
 (defun chatgpt-shell-openai--validate-command (_command _model _settings)
   "Return error string if command/setup isn't valid."

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -8,6 +8,7 @@
          :key #'chatgpt-shell-openrouter-key
          :headers #'chatgpt-shell-openrouter--make-headers
          :handler #'chatgpt-shell-openrouter--handle-chatgpt-command
+         :filter #'chatgpt-shell-openrouter--filter-output
          args))
 
 (defun chatgpt-shell-openrouter-models ()
@@ -42,13 +43,13 @@
          ;;
          ;; See https://openrouter.ai/qwen/qwq-32b-preview
          :other-params '((provider (quantizations . ["bf16"]))))
-        ;; (chatgpt-shell-openrouter-make-model
-        ;;  :version "openai/o1"
-        ;;  :short-version "o1"
-        ;;  :label "ChatGPT"
-        ;;  :token-width 3
-        ;;  ;; See https://openrouter.ai/openai/o1-2024-12-17
-        ;;  :context-window 200000)
+        (chatgpt-shell-openrouter-make-model
+         :version "openai/o1"
+         :short-version "o1"
+         :label "ChatGPT"
+         :token-width 3
+         ;; See https://openrouter.ai/openai/o1-2024-12-17
+         :context-window 200000)
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
          :short-version "qwen-2.5-coder-32b"
@@ -97,6 +98,10 @@ If you use OpenRouter through a proxy service, change the URL base."
   (apply #'chatgpt-shell-openai--handle-chatgpt-command
          :key #'chatgpt-shell-openrouter-key
          args))
+
+(defun chatgpt-shell-openrouter--filter-output (raw-response)
+  (unless (string= (string-trim raw-response) ": OPENROUTER PROCESSING")
+    (chatgpt-shell-openai--filter-output raw-response)))
 
 (defun chatgpt-shell-openrouter--make-headers (&rest args)
   (apply #'chatgpt-shell-openai--make-headers

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -45,5 +45,23 @@
          ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
          :other-params '((provider (quantizations . ["bf16"]))))))
 
+(defcustom chatgpt-shell-openrouter-key nil
+  "OpenRouter key as a string or a function that loads and returns it."
+  :type '(choice (function :tag "Function")
+                 (string :tag "String"))
+  :group 'chatgpt-shell)
+
+(defun chatgpt-shell-openrouter-key ()
+  "Get the OpenRouter key."
+  (cond ((stringp chatgpt-shell-openrouter-key)
+         chatgpt-shell-openrouter-key)
+        ((functionp chatgpt-shell-openrouter-key)
+         (condition-case _err
+             (funcall chatgpt-shell-openrouter-key)
+           (error
+            "KEY-NOT-FOUND")))
+        (t
+         nil)))
+
 (provide 'chatgpt-shell-openrouter)
 ;;; chatgpt-shell-openrouter.el ends here

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -1,0 +1,49 @@
+;;; chatgpt-shell-openrouter.el --- OpenRouter-specific logic -*- lexical-binding: t; -*-
+
+(defun chatgpt-shell-openrouter-models ()
+  "Build a list of OpenRouter LLM models."
+  (list (chatgpt-shell-openai-make-model
+         :version "meta-llama/llama-3.3-70b-instruct"
+         :provider "OpenRouter"
+         :token-width 16
+         ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
+         :context-window 131072
+         ;; Multiple quantizations are offered for this model by different
+         ;; providers so we restrict to one for consistency. Note that the sense
+         ;; in which provider is used here means the providers available through
+         ;; OpenRouter. This is different from the meaning of the :provider
+         ;; argument.
+         ;;
+         ;; See https://openrouter.ai/docs/provider-routing#quantization
+         :other-params '((provider (quantizations . ["bf16"]))))
+        (chatgpt-shell-openai-make-model
+         :version "qwen/qwq-32b-preview"
+         :provider "OpenRouter"
+         :token-width 16
+         ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
+         :context-window 32768
+         ;; Multiple quantizations are offered for this model by different
+         ;; providers so we restrict to one for consistency. Note that the sense
+         ;; in which provider is used here means the providers available through
+         ;; OpenRouter. This is different from the meaning of the :provider
+         ;; argument.
+         ;;
+         ;; See https://openrouter.ai/docs/provider-routing#quantization
+         :other-params '((provider (quantizations . ["bf16"]))))
+        (chatgpt-shell-openai-make-model
+         :version "qwen/qwen-2.5-coder-32b-instruct"
+         :provider "OpenRouter"
+         :token-width 16
+         ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
+         :context-window 32768
+         ;; Multiple quantizations are offered for this model by different
+         ;; providers so we restrict to one for consistency. Note that the sense
+         ;; in which provider is used here means the providers available through
+         ;; OpenRouter. This is different from the meaning of the :provider
+         ;; argument.
+         ;;
+         ;; See https://openrouter.ai/docs/provider-routing#quantization
+         :other-params '((provider (quantizations . ["bf16"]))))))
+
+(provide 'chatgpt-shell-openrouter)
+;;; chatgpt-shell-openrouter.el ends here

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -2,9 +2,9 @@
 
 (cl-defun chatgpt-shell-openrouter-make-model (&rest args &key version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
-         args
          :provider "OpenRouter"
-         :key #'chatgpt-shell-openrouter-key))
+         :key #'chatgpt-shell-openrouter-key
+         args))
 
 (defun chatgpt-shell-openrouter-models ()
   "Build a list of OpenRouter LLM models."

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -20,7 +20,7 @@
          :version "qwen/qwq-32b-preview"
          :provider "OpenRouter"
          :token-width 16
-         ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
+         ;; See
          :context-window 32768
          ;; Multiple quantizations are offered for this model by different
          ;; providers so we restrict to one for consistency. Note that the sense
@@ -28,13 +28,13 @@
          ;; OpenRouter. This is different from the meaning of the :provider
          ;; argument.
          ;;
-         ;; See https://openrouter.ai/docs/provider-routing#quantization
+         ;; See https://openrouter.ai/qwen/qwq-32b-preview
          :other-params '((provider (quantizations . ["bf16"]))))
         (chatgpt-shell-openai-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
          :provider "OpenRouter"
          :token-width 16
-         ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
+         ;; See
          :context-window 32768
          ;; Multiple quantizations are offered for this model by different
          ;; providers so we restrict to one for consistency. Note that the sense
@@ -42,7 +42,7 @@
          ;; OpenRouter. This is different from the meaning of the :provider
          ;; argument.
          ;;
-         ;; See https://openrouter.ai/docs/provider-routing#quantization
+         ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
          :other-params '((provider (quantizations . ["bf16"]))))))
 
 (provide 'chatgpt-shell-openrouter)

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -2,7 +2,7 @@
 
 (cl-defun chatgpt-shell-openrouter-make-model (&rest args &key label version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
-         :validate-command chatgpt-shell-openrouter--validate-command
+         :validate-command #'chatgpt-shell-openrouter--validate-command
          :url-base 'chatgpt-shell-openrouter-api-url-base
          :path "/v1/chat/completions"
          :provider "OpenRouter"

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -49,7 +49,8 @@
          :label "ChatGPT"
          :token-width 3
          ;; See https://openrouter.ai/openai/o1-2024-12-17
-         :context-window 200000)
+         :context-window 200000
+         :validate-command #'chatgpt-shell-validate-no-system-prompt)
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
          :short-version "qwen-2.5-coder-32b"
@@ -97,6 +98,7 @@ If you use OpenRouter through a proxy service, change the URL base."
 (defun chatgpt-shell-openrouter--handle-chatgpt-command (&rest args &key model command context shell settings)
   (apply #'chatgpt-shell-openai--handle-chatgpt-command
          :key #'chatgpt-shell-openrouter-key
+         :filter #'chatgpt-shell-openrouter--filter-output
          args))
 
 (defun chatgpt-shell-openrouter--filter-output (raw-response)

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -1,10 +1,15 @@
 ;;; chatgpt-shell-openrouter.el --- OpenRouter-specific logic -*- lexical-binding: t; -*-
 
+(cl-defun chatgpt-shell-openrouter-make-model (&rest args &key version short-version token-width context-window validate-command other-params)
+  (apply #'chatgpt-shell-openai-make-model
+         args
+         :provider "OpenRouter"
+         :key #'chatgpt-shell-openrouter-key))
+
 (defun chatgpt-shell-openrouter-models ()
   "Build a list of OpenRouter LLM models."
   (list (chatgpt-shell-openai-make-model
          :version "meta-llama/llama-3.3-70b-instruct"
-         :provider "OpenRouter"
          :token-width 16
          ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
          :context-window 131072
@@ -18,7 +23,6 @@
          :other-params '((provider (quantizations . ["bf16"]))))
         (chatgpt-shell-openai-make-model
          :version "qwen/qwq-32b-preview"
-         :provider "OpenRouter"
          :token-width 16
          ;; See
          :context-window 32768
@@ -32,7 +36,6 @@
          :other-params '((provider (quantizations . ["bf16"]))))
         (chatgpt-shell-openai-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
-         :provider "OpenRouter"
          :token-width 16
          ;; See
          :context-window 32768

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -8,7 +8,7 @@
 
 (defun chatgpt-shell-openrouter-models ()
   "Build a list of OpenRouter LLM models."
-  (list (chatgpt-shell-openai-make-model
+  (list (chatgpt-shell-openrouter-make-model
          :version "meta-llama/llama-3.3-70b-instruct"
          :token-width 16
          ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
@@ -21,7 +21,7 @@
          ;;
          ;; See https://openrouter.ai/docs/provider-routing#quantization
          :other-params '((provider (quantizations . ["bf16"]))))
-        (chatgpt-shell-openai-make-model
+        (chatgpt-shell-openrouter-make-model
          :version "qwen/qwq-32b-preview"
          :token-width 16
          ;; See
@@ -34,7 +34,7 @@
          ;;
          ;; See https://openrouter.ai/qwen/qwq-32b-preview
          :other-params '((provider (quantizations . ["bf16"]))))
-        (chatgpt-shell-openai-make-model
+        (chatgpt-shell-openrouter-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
          :token-width 16
          ;; See

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -10,6 +10,7 @@
   "Build a list of OpenRouter LLM models."
   (list (chatgpt-shell-openrouter-make-model
          :version "meta-llama/llama-3.3-70b-instruct"
+         :short-version "llama-3.3-70b"
          :token-width 16
          ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
          :context-window 131072
@@ -23,6 +24,7 @@
          :other-params '((provider (quantizations . ["bf16"]))))
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwq-32b-preview"
+         :short-version "qwq-32b-preview"
          :token-width 16
          ;; See
          :context-window 32768
@@ -36,6 +38,7 @@
          :other-params '((provider (quantizations . ["bf16"]))))
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
+         :short-version "qwen-2.5-coder-32b"
          :token-width 16
          ;; See
          :context-window 32768

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -54,7 +54,7 @@
          ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
          :other-params '((provider (quantizations . ["bf16"]))))))
 
-(defcustom chatgpt-shell-openrouter-api-url-base "https://openrouter.ai"
+(defcustom chatgpt-shell-openrouter-api-url-base "https://openrouter.ai/api"
   "OpenRouter API's base URL.
 
 API url = base + path.

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -5,6 +5,7 @@
          :url-base chatgpt-shell-openrouter-api-url-base
          :provider "OpenRouter"
          :key #'chatgpt-shell-openrouter-key
+         :headers #'chatgpt-shell-openrouter--make-headers
          :handler #'chatgpt-shell-openrouter--handle-chatgpt-command
          args))
 
@@ -83,6 +84,11 @@ If you use OpenRouter through a proxy service, change the URL base."
 
 (defun chatgpt-shell-openrouter--handle-chatgpt-command (&rest args &key model command context shell settings)
   (apply #'chatgpt-shell-openai--handle-chatgpt-command
+         :key #'chatgpt-shell-openrouter-key
+         args))
+
+(defun chatgpt-shell-openrouter--make-headers (&rest args)
+  (apply #'chatgpt-shell-openai--make-headers
          :key #'chatgpt-shell-openrouter-key
          args))
 

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -2,7 +2,7 @@
 
 (cl-defun chatgpt-shell-openrouter-make-model (&rest args &key version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
-         :url-base chatgpt-shell-openrouter-api-url-base
+         :url-base 'chatgpt-shell-openrouter-api-url-base
          :provider "OpenRouter"
          :key #'chatgpt-shell-openrouter-key
          :headers #'chatgpt-shell-openrouter--make-headers
@@ -54,7 +54,7 @@
          ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
          :other-params '((provider (quantizations . ["bf16"]))))))
 
-(defcustom chatgpt-shell-openrouter-api-url-base "https://openrouter.ai/api/v1"
+(defcustom chatgpt-shell-openrouter-api-url-base "https://openrouter.ai"
   "OpenRouter API's base URL.
 
 API url = base + path.

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -2,6 +2,7 @@
 
 (cl-defun chatgpt-shell-openrouter-make-model (&rest args &key label version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
+         :validate-command chatgpt-shell-openrouter--validate-command
          :url-base 'chatgpt-shell-openrouter-api-url-base
          :path "/v1/chat/completions"
          :provider "OpenRouter"
@@ -99,6 +100,7 @@ If you use OpenRouter through a proxy service, change the URL base."
   (apply #'chatgpt-shell-openai--handle-chatgpt-command
          :key #'chatgpt-shell-openrouter-key
          :filter #'chatgpt-shell-openrouter--filter-output
+         :missing-key-msg "Your chatgpt-shell-openrouter-key is missing"
          args))
 
 (defun chatgpt-shell-openrouter--filter-output (raw-response)
@@ -109,6 +111,17 @@ If you use OpenRouter through a proxy service, change the URL base."
   (apply #'chatgpt-shell-openai--make-headers
          :key #'chatgpt-shell-openrouter-key
          args))
+
+(defun chatgpt-shell-openrouter--validate-command (_command _model _settings)
+  "Return error string if command/setup isn't valid."
+  (unless chatgpt-shell-openrouter-key
+    "Variable `chatgpt-shell-openrouter-key' needs to be set to your key.
+
+Try M-x set-variable chatgpt-shell-openrouter-key
+
+or
+
+(setq chatgpt-shell-openrouter-key \"my-key\")"))
 
 (provide 'chatgpt-shell-openrouter)
 ;;; chatgpt-shell-openrouter.el ends here

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -1,8 +1,9 @@
 ;;; chatgpt-shell-openrouter.el --- OpenRouter-specific logic -*- lexical-binding: t; -*-
 
-(cl-defun chatgpt-shell-openrouter-make-model (&rest args &key version short-version token-width context-window validate-command other-params)
+(cl-defun chatgpt-shell-openrouter-make-model (&rest args &key label version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
          :url-base 'chatgpt-shell-openrouter-api-url-base
+         :path "/v1/chat/completions"
          :provider "OpenRouter"
          :key #'chatgpt-shell-openrouter-key
          :headers #'chatgpt-shell-openrouter--make-headers
@@ -14,6 +15,7 @@
   (list (chatgpt-shell-openrouter-make-model
          :version "meta-llama/llama-3.3-70b-instruct"
          :short-version "llama-3.3-70b"
+         :label "Llama"
          :token-width 16
          ;; See https://openrouter.ai/meta-llama/llama-3.3-70b-instruct.
          :context-window 131072
@@ -28,6 +30,7 @@
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwq-32b-preview"
          :short-version "qwq-32b-preview"
+         :label "Qwen"
          :token-width 16
          ;; See
          :context-window 32768
@@ -39,9 +42,17 @@
          ;;
          ;; See https://openrouter.ai/qwen/qwq-32b-preview
          :other-params '((provider (quantizations . ["bf16"]))))
+        ;; (chatgpt-shell-openrouter-make-model
+        ;;  :version "openai/o1"
+        ;;  :short-version "o1"
+        ;;  :label "ChatGPT"
+        ;;  :token-width 3
+        ;;  ;; See https://openrouter.ai/openai/o1-2024-12-17
+        ;;  :context-window 200000)
         (chatgpt-shell-openrouter-make-model
          :version "qwen/qwen-2.5-coder-32b-instruct"
          :short-version "qwen-2.5-coder-32b"
+         :label "Qwen"
          :token-width 16
          ;; See
          :context-window 32768

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -2,6 +2,7 @@
 
 (cl-defun chatgpt-shell-openrouter-make-model (&rest args &key version short-version token-width context-window validate-command other-params)
   (apply #'chatgpt-shell-openai-make-model
+         :url-base chatgpt-shell-openrouter-api-url-base
          :provider "OpenRouter"
          :key #'chatgpt-shell-openrouter-key
          args))
@@ -50,6 +51,16 @@
          ;;
          ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
          :other-params '((provider (quantizations . ["bf16"]))))))
+
+(defcustom chatgpt-shell-openrouter-api-url-base "https://openrouter.ai/api/v1"
+  "OpenRouter API's base URL.
+
+API url = base + path.
+
+If you use OpenRouter through a proxy service, change the URL base."
+  :type 'string
+  :safe #'stringp
+  :group 'chatgpt-shell)
 
 (defcustom chatgpt-shell-openrouter-key nil
   "OpenRouter key as a string or a function that loads and returns it."

--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -5,6 +5,7 @@
          :url-base chatgpt-shell-openrouter-api-url-base
          :provider "OpenRouter"
          :key #'chatgpt-shell-openrouter-key
+         :handler #'chatgpt-shell-openrouter--handle-chatgpt-command
          args))
 
 (defun chatgpt-shell-openrouter-models ()
@@ -79,6 +80,11 @@ If you use OpenRouter through a proxy service, change the URL base."
             "KEY-NOT-FOUND")))
         (t
          nil)))
+
+(defun chatgpt-shell-openrouter--handle-chatgpt-command (&rest args &key model command context shell settings)
+  (apply #'chatgpt-shell-openai--handle-chatgpt-command
+         :key #'chatgpt-shell-openrouter-key
+         args))
 
 (provide 'chatgpt-shell-openrouter)
 ;;; chatgpt-shell-openrouter.el ends here

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -401,6 +401,12 @@ Or nil if none."
         (push key seen)))
     duplicates))
 
+(defun chatgpt-shell-validate-no-system-prompt (command model settings)
+    (or (chatgpt-shell-openai--validate-command command model settings)
+        (when (map-elt settings :system-prompt)
+          (format "Model \"%s\" does not support system prompts. Please unset via \"M-x chatgpt-shell-swap-system-prompt\" by selecting None."
+                  (map-elt model :version)))))
+
 ;;;###autoload
 (defun chatgpt-shell-swap-system-prompt ()
   "Swap system prompt from `chatgpt-shell-system-prompts'."

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -57,6 +57,7 @@
 (require 'chatgpt-shell-ollama)
 (require 'chatgpt-shell-openai)
 (require 'chatgpt-shell-perplexity)
+(require 'chatgpt-shell-openrouter)
 
 (defcustom chatgpt-shell-request-timeout 600
   "How long to wait for a request to time out in seconds."
@@ -216,7 +217,8 @@ It returns a list containing all available models from these providers."
           (chatgpt-shell-google-models)
           (chatgpt-shell-kagi-models)
           (chatgpt-shell-ollama-models)
-          (chatgpt-shell-perplexity-models)))
+          (chatgpt-shell-perplexity-models)
+          (chatgpt-shell-openrouter-models)))
 
 (defcustom chatgpt-shell-models
   (chatgpt-shell--make-default-models)

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1902,7 +1902,8 @@ ON-FAILURE: (lambda (output)) for completion event."
             :system-prompt system-prompt
             :version (map-elt model :version)
             :temperature (or temperature 1)
-            :streaming streaming)
+            :streaming streaming
+            :other-params (map-elt model :other-params))
      :headers headers
      :filter #'chatgpt-shell-openai--filter-output
      :on-output


### PR DESCRIPTION
This adds support for various llama and qwen models via OpenRouter. It also adds support for OpenAI's o1 model which is currently only available to teir 5 API users.