### PR TITLE
Put the whole chatgpt shell buffer name inside the earmuffs

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -850,7 +850,7 @@ This is used for sending a prompt to in the background."
 
 (defun chatgpt-shell--make-buffer-name ()
   "Generate a buffer name using current shell config info."
-  (format "*%s llm* %s"
+  (format "*%s llm (%s*)"
           (downcase (chatgpt-shell--model-label))
           (chatgpt-shell--shell-info)))
 


### PR DESCRIPTION
This is for consistency with other shell-style buffers in Emacs