### PR TITLE
Use cl-defun in openrouter for &key params

### DIFF
--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -120,7 +120,7 @@ If you use OpenRouter through a proxy service, change the URL base."
         (t
          nil)))
 
-(defun chatgpt-shell-openrouter--handle-chatgpt-command (&rest args &key model command context shell settings)
+(cl-defun chatgpt-shell-openrouter--handle-chatgpt-command (&rest args &key model command context shell settings)
   "Handle ChatGPT COMMAND (prompt) using ARGS, MODEL, CONTEXT, SHELL, and SETTINGS."
   (apply #'chatgpt-shell-openai--handle-chatgpt-command
          :key #'chatgpt-shell-openrouter-key


### PR DESCRIPTION
Using only `defun` results in errors during byte compilation:

```
Compiling file /home/ad/git/chatgpt-shell/chatgpt-shell-openrouter.el at Thu Jan  2 20:14:24 2025
chatgpt-shell-openrouter.el:123:2: Error: Garbage following &rest VAR in lambda-list
```