### PR TITLE
feat: discover Gemini models dynamically via API

### DIFF
--- a/chatgpt-shell-google.el
+++ b/chatgpt-shell-google.el
@@ -119,9 +119,15 @@ the model description needed by chatgpt-shell ."
         (model-cwindow (gethash "inputTokenLimit" model)))
     (let ((model-version (string-remove-prefix "models/" model-name)))
       (let ((model-shortversion (string-remove-prefix "gemini-" model-version))
-            (model-urlpath (concat "/v1beta/" model-name)))
+            (model-urlpath (concat "/v1beta/" model-name))
+            ;; The model descriptor does not stipulate whether grounding is supported.
+            ;; So this logic just checks the name.
+            (model-supports-grounding (or
+                                       (string-prefix-p "gemini-1.5" model-version)
+                                       (string-prefix-p "gemini-2.0" model-version))))
         (chatgpt-shell-google-make-model :version model-version
                                          :short-version model-shortversion
+                                         :grounding-search model-supports-grounding
                                          :path model-urlpath
                                          :token-width 4
                                          :context-window model-cwindow)))))

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -119,7 +119,11 @@
   :group 'chatgpt-shell)
 
 (defcustom chatgpt-shell-prompt-header-proofread-region
-  "Please help me proofread the following English text and only reply with fixed text:"
+  "Please help me proofread the following English text and only reply with fixed text.
+Output just the proofread text without any intro, comments, or explanations.
+If the original text was indented on the left, preserve the same amount of spacing in your response:
+
+"
   "Prompt header used by `chatgpt-shell-proofread-region`."
   :type 'string
   :group 'chatgpt-shell)


### PR DESCRIPTION
Discover Gemini models via the API. 

This requires an API key, so it may need a fallback if you'd like the "fixed list" to work when no API key is available.