### PR TITLE
Change some openai models and add new models

### DIFF
--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -71,6 +71,11 @@ HANDLER, FILTER and OTHER-PARAMS."
   "Build a list of all OpenAI LLM models available."
   ;; Context windows have been verified as of 11/26/2024.
   (list (chatgpt-shell-openai-make-model
+         :version "chatgpt-4o-latest"
+         :token-width 3
+         ;; https://platform.openai.com/docs/models/chatgpt-4o-latest
+         :context-window 128000)
+        (chatgpt-shell-openai-make-model
          :version "gpt-4o"
          :token-width 3
          ;; https://platform.openai.com/docs/models/gpt-4o
@@ -89,11 +94,6 @@ HANDLER, FILTER and OTHER-PARAMS."
          :version "gpt-4o-mini-search-preview"
          :token-width 3
          ;; https://platform.openai.com/docs/models/gpt-4o-mini-search-preview
-         :context-window 128000)
-        (chatgpt-shell-openai-make-model
-         :version "chatgpt-4o-latest"
-         :token-width 3
-         ;; https://platform.openai.com/docs/models/chatgpt-4o-latest
          :context-window 128000)
         (chatgpt-shell-openai-make-model
          :version "o3-mini"

--- a/chatgpt-shell-openai.el
+++ b/chatgpt-shell-openai.el
@@ -71,9 +71,29 @@ HANDLER, FILTER and OTHER-PARAMS."
   "Build a list of all OpenAI LLM models available."
   ;; Context windows have been verified as of 11/26/2024.
   (list (chatgpt-shell-openai-make-model
-         :version "chatgpt-4o-latest"
+         :version "gpt-4o"
          :token-width 3
          ;; https://platform.openai.com/docs/models/gpt-4o
+         :context-window 128000)
+        (chatgpt-shell-openai-make-model
+         :version "gpt-4o-search-preview"
+         :token-width 3
+         ;; https://platform.openai.com/docs/models/gpt-4o-search-preview
+         :context-window 128000)
+        (chatgpt-shell-openai-make-model
+         :version "gpt-4o-mini"
+         :token-width 3
+         ;; https://platform.openai.com/docs/models/gpt-4o-mini
+         :context-window 128000)
+        (chatgpt-shell-openai-make-model
+         :version "gpt-4o-mini-search-preview"
+         :token-width 3
+         ;; https://platform.openai.com/docs/models/gpt-4o-mini-search-preview
+         :context-window 128000)
+        (chatgpt-shell-openai-make-model
+         :version "chatgpt-4o-latest"
+         :token-width 3
+         ;; https://platform.openai.com/docs/models/chatgpt-4o-latest
          :context-window 128000)
         (chatgpt-shell-openai-make-model
          :version "o3-mini"
@@ -114,11 +134,6 @@ HANDLER, FILTER and OTHER-PARAMS."
          :version "gpt-4.5-preview"
          :token-width 3
          ;; https://platform.openai.com/docs/models#gpt-4-5
-         :context-window 128000)
-        (chatgpt-shell-openai-make-model
-         :version "gpt-4o"
-         :token-width 3
-         ;; https://platform.openai.com/docs/models/gpt-40
          :context-window 128000)
         (chatgpt-shell-openai-make-model
          :version "gpt-3.5-turbo"


### PR DESCRIPTION
Just noticed there are several changes on openai API side:

+ `chatgpt-4o-latest` document link change to [https://platform.openai.com/docs/models/chatgpt-4o-latest](https://platform.openai.com/docs/models/chatgpt-4o-latest) 
+ [https://platform.openai.com/docs/models/gpt-4o](https://platform.openai.com/docs/models/gpt-4o) link to the other model gpt-4o

Several changes:

+ `gpt-4o` is much cheaper, so I move it to be the first option than `chatgpt-4o-latest`
+ also add the `gpt-4o-mini`
+ added two models those can search web `gpt-4o-search-preview` and `gpt-4o-mini-search-preview`