### PR TITLE
fix: handle case where google model lacks description

### DIFF
--- a/chatgpt-shell-google.el
+++ b/chatgpt-shell-google.el
@@ -94,8 +94,9 @@ supports \"generateContent\".
 This is used to filter the list of models returned from
 https://generativelanguage.googleapis.com"
   (let-alist api-response
-    (unless (string-match-p (rx (or "discontinued" "deprecated")) .description)
-      (seq-contains-p .supportedGenerationMethods "generateContent"))))
+    (and .supportedGenerationMethods
+         (not (and .description (string-match-p (rx (or "discontinued" "deprecated")) .description)))
+         (seq-contains-p .supportedGenerationMethods "generateContent"))))
 
 (defun chatgpt-shell-google--fetch-model-versions ()
   "Retrieves the list of generative models from the Google API."


### PR DESCRIPTION
This fixes #325 .

The `chatgpt-shell-google--fetch-model-versions` fn loads model descriptions from Google via a GET to https://generativelanguage.googleapis.com/v1beta/models 

The response is a set of records like the following. 
```
    {
      "name": "models/gemini-2.0-flash-exp",
      "version": "2.0",
      "displayName": "Gemini 2.0 Flash Experimental",
      "description": "Gemini 2.0 Flash Experimental",
      "inputTokenLimit": 1048576,
      "outputTokenLimit": 8192,
      "supportedGenerationMethods": [
        "generateContent",
        "countTokens",
        "bidiGenerateContent"
      ],
      "temperature": 1,
      "topP": 0.95,
      "topK": 40,
      "maxTemperature": 2
    },
```

In cases in which the model is deprecated, the `description` field has contained the word "deprecated".  so the logic in 
`chatgpt-shell-google--fetch-model-versions`  filters out such records.  In some cases, the data returned by Google does not include any description. Eg

```
    {
      "name": "models/gemma-3-27b-it",
      "version": "001",
      "displayName": "Gemma 3 27B",
      "inputTokenLimit": 131072,
      "outputTokenLimit": 8192,
      "supportedGenerationMethods": [
        "generateContent",
        "countTokens"
      ],
      "temperature": 1,
      "topP": 0.95,
      "topK": 64
    },
```

This change handles that case. With this change, the current Gemma model can be loaded. 

I observed a separate problem _using_ the Gemma model. It returns
```
Developer instruction is not enabled for models/gemma-3-27b-it
```

This is a matter of API usage.  