### PR TITLE
Add transient menu

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,34 +85,47 @@ LLM being lazy and returning partial code? Press =e= to request entire snippet.
 
    Invoke it with =C-c C-t= while inside a =chatgpt-shell= buffer.
 
+   The menu is organized into logical groups for easy navigation:
+
    #+BEGIN_SRC text :exports code
      ┌──────────────────────────────────────────────────────────────────────────────┐
-     │ ChatGPT Shell actions           Shell Context Actions                        │
-     │ Core Shell & Compose            Shell Buffer Management                      │
-     │ s: Focus/Start Shell            C: Clear Shell Buffer                        │
-     │ N: Start New Shell              I: Interrupt Request                         │
-     │ e: Compose Prompt               Shell Navigation                             │
-     │ p: Prompt (minibuffer)          h: Search History                            │
-     │ P: Prompt (append kill)         j: Next Item                                 │
-     │ q: Quick Insert                 k: Previous Item                             │
-     │ Region Actions                  J: Next Source Block                         │
-     │ r: Send Region                  K: Previous Source Block                     │
-     │ R: Send & Review Region         Block Actions                                │
-     │ d: Describe Code                x: Execute Block                             │
-     │ f: Refactor Code                E: Edit Block                                │
-     │ g: Write Git Commit             V: View Block                                │
-     │ t: Generate Unit Test           Shell Configuration                          │
-     │ w: Proofread Region             m: Swap Model                                │
-     │                                 y: Swap System Prompt                        │
-     │                                 Shell Session                                │
-     │                                 S: Save Transcript                           │
-     │                                 O: Restore Transcript                        │
-     │ Configuration & Utilities                                                    │
-     │ Model & Configuration                                                        │
-     │ L: Reload Default Models                                                     │
+     │ Shells                          Compose prompt via              Inline edit  │
+     │ b: Switch to shell buffer       e: Dedicated buffer             q: Quick     │
+     │ N: Create new shell             p: Minibuffer                      insert/   │
+     │                                 P: Minibuffer (include last        edit      │
+     │                                    kill)                        r: Send      │
+     │                                                                    region    │
+     │                                                                 R: Send &    │
+     │                                                                    review    │
+     │                                                                    region    │
+     │                                                                              │
+     │ Session                         History                         Navigation   │
+     │ m: Swap model                   h: Search                       n: Next item │
+     │ L: Reload models                                                p: Previous  │
+     │ y: Swap system prompt                                              item      │
+     │                                                                 TAB: Next    │
+     │                                                                      source  │
+     │                                                                      block   │
+     │                                                                 <backtab>:   │
+     │                                                                      Previous│
+     │                                                                      source  │
+     │                                                                      block   │
+     │                                                                              │
+     │ Source blocks                   Transcript                      Code Actions │
+     │ C-c C-c: Execute                S: Save                         d: Describe  │
+     │ E: Edit                         O: Restore                         code      │
+     │ V: View                                                         f: Refactor  │
+     │                                                                    code      │
+     │                                                                 g: Write git │
+     │                                                                    commit    │
+     │                                                                 t: Generate  │
+     │                                                                    unit test │
+     │                                                                 w: Proofread │
+     │                                                                              │
      │ Other                                                                        │
-     │ i: Describe Image                                                            │
-     │ v: Show Version                                                              │
+     │ C: Clear buffer                                                              │
+     │ I: Interrupt                                                                 │
+     │ v: Show version                                                              │
      └──────────────────────────────────────────────────────────────────────────────┘
    #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -76,6 +76,60 @@ I'm a big fan of quickly disposing of Emacs buffers with the =q= binding. chatgp
 
 LLM being lazy and returning partial code? Press =e= to request entire snippet.
 
+*** Quick Actions with Transient Menu
+
+   For quick access to common actions, =chatgpt-shell= provides a transient menu,
+   powered by the excellent [[https://github.com/magit/transient][transient]] package. Think of it as a temporary keymap
+   overlay that pops up, shows you available commands with their keybindings,
+   and disappears after you select one.
+
+   Invoke it with =C-c C-t= while inside a =chatgpt-shell= buffer.
+
+   #+BEGIN_SRC text :exports code
+     ┌──────────────────────────────────────────────────────────────────────────────┐
+     │ ChatGPT Shell actions           Shell Context Actions                        │
+     │ Core Shell & Compose            Shell Buffer Management                      │
+     │ s: Focus/Start Shell            C: Clear Shell Buffer                        │
+     │ N: Start New Shell              I: Interrupt Request                         │
+     │ e: Compose Prompt               Shell Navigation                             │
+     │ p: Prompt (minibuffer)          h: Search History                            │
+     │ P: Prompt (append kill)         j: Next Item                                 │
+     │ q: Quick Insert                 k: Previous Item                             │
+     │ Region Actions                  J: Next Source Block                         │
+     │ r: Send Region                  K: Previous Source Block                     │
+     │ R: Send & Review Region         Block Actions                                │
+     │ d: Describe Code                x: Execute Block                             │
+     │ f: Refactor Code                E: Edit Block                                │
+     │ g: Write Git Commit             V: View Block                                │
+     │ t: Generate Unit Test           Shell Configuration                          │
+     │ w: Proofread Region             m: Swap Model                                │
+     │                                 y: Swap System Prompt                        │
+     │                                 Shell Session                                │
+     │                                 S: Save Transcript                           │
+     │                                 O: Restore Transcript                        │
+     │ Configuration & Utilities                                                    │
+     │ Model & Configuration                                                        │
+     │ L: Reload Default Models                                                     │
+     │ Other                                                                        │
+     │ i: Describe Image                                                            │
+     │ v: Show Version                                                              │
+     └──────────────────────────────────────────────────────────────────────────────┘
+   #+END_SRC
+
+   (Note: The exact commands shown depend on context, like whether a region is active
+   or if you are inside a =chatgpt-shell= buffer.)
+
+   If you prefer a global keybinding (available everywhere in Emacs), you can add
+   something like this to your personal Emacs configuration:
+
+   #+begin_src emacs-lisp :lexical no
+     ;; In your init.el or equivalent
+     (global-set-key (kbd "C-c C-g") 'chatgpt-shell-transient)
+   #+end_src
+
+   This menu helps with discovering available commands and executing them quickly
+   without needing to remember every single keybinding or =M-x= command name.
+
 ** Confirm inline mods (via diffs)
 
 Request inline modifications, with explicit confirmation before accepting.

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -1,0 +1,73 @@
+;;; chatgpt-shell-transient.el --- Transient menus for chatgpt-shell -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Provides transient menus for interacting with chatgpt-shell.
+
+;;; Code:
+
+(require 'transient)
+(require 'chatgpt-shell) ;; Ensure the main functions are loaded
+
+;;;###autoload
+(transient-define-prefix chatgpt-shell-transient--popup ()
+  "Transient menu for chatgpt-shell commands."
+  [
+   "ChatGPT Shell actions"
+   ["Core Shell & Compose"
+    ("s" "Focus/Start Shell" chatgpt-shell)
+    ("N" "Start New Shell" (lambda () (interactive) (chatgpt-shell t)))
+     ("C" "Clear Shell Buffer" chatgpt-shell-clear-buffer)
+     ("K" "Interrupt Request" chatgpt-shell-interrupt)
+     ("e" "Compose Prompt" chatgpt-shell-prompt-compose)
+     ("p" "Prompt (minibuffer)" chatgpt-shell-prompt)
+     ("P" "Prompt (append kill)" chatgpt-shell-prompt-appending-kill-ring)
+     ("q" "Quick Insert" chatgpt-shell-quick-insert)]
+
+    ["Region Actions"
+     ("r" "Send Region" (lambda () (interactive) (chatgpt-shell-send-region nil)))
+     ("R" "Send & Review Region" chatgpt-shell-send-and-review-region)
+     ("d" "Describe Code" chatgpt-shell-describe-code)
+     ("f" "Refactor Code" chatgpt-shell-refactor-code)
+     ("g" "Write Git Commit" chatgpt-shell-write-git-commit)
+     ("t" "Generate Unit Test" chatgpt-shell-generate-unit-test)
+     ("w" "Proofread Region" chatgpt-shell-proofread-region)]
+
+   ["Shell Navigation"
+    ("h" "Search History" chatgpt-shell-search-history)
+    ("j" "Next Item" chatgpt-shell-next-item)
+    ("k" "Previous Item" chatgpt-shell-previous-item)
+     ("J" "Next Source Block" chatgpt-shell-next-source-block)
+     ("K" "Previous Source Block" chatgpt-shell-previous-source-block)]
+
+    ["Block Actions"
+     ("x" "Execute Block" chatgpt-shell-execute-babel-block-action-at-point)
+     ("E" "Edit Block" chatgpt-shell-edit-block-at-point)
+     ("V" "View Block" chatgpt-shell-view-block-at-point)]
+   ]
+
+  [
+   "Configuration & Utilities"
+   ["Model & Configuration"
+    ("m" "Swap Model" chatgpt-shell-swap-model)
+    ("y" "Swap System Prompt" chatgpt-shell-swap-system-prompt)
+     ("L" "Reload Default Models" chatgpt-shell-reload-default-models)]
+
+    ["Session & Other"
+     ("S" "Save Transcript" chatgpt-shell-save-session-transcript)
+     ("O" "Restore Transcript" chatgpt-shell-restore-session-from-transcript)
+     ("i" "Describe Image" chatgpt-shell-describe-image)
+     ("v" "Show Version" chatgpt-shell-version)]
+   ]
+  )
+
+
+;;;###autoload
+(defun chatgpt-shell-transient ()
+  "Invoke the main transient menu for chatgpt-shell."
+  (interactive)
+  ;; Call the correctly named transient prefix command
+  (chatgpt-shell-transient--popup))
+
+(provide 'chatgpt-shell-transient)
+
+;;; chatgpt-shell-transient.el ends here

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -55,7 +55,11 @@
     ("I" "Interrupt Request" chatgpt-shell-interrupt :if chatgpt-shell-transient--in-shell-p)]
 
    ["Shell Navigation"
-    ("h" "Search History" chatgpt-shell-search-history :if chatgpt-shell-transient--in-shell-p)
+    ("h" "Search History"
+     (lambda ()
+       (interactive)
+       (transient-quit-one)
+       (run-with-idle-timer 0 nil #'chatgpt-shell-search-history)) :if chatgpt-shell-transient--in-shell-p)
     ("j" "Next Item" chatgpt-shell-next-item :if chatgpt-shell-transient--in-shell-p)
     ("k" "Previous Item" chatgpt-shell-previous-item :if chatgpt-shell-transient--in-shell-p)
     ("J" "Next Source Block" chatgpt-shell-next-source-block :if chatgpt-shell-transient--in-shell-p)

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -8,7 +8,6 @@
 (require 'transient)
 (require 'chatgpt-shell) ;; Ensure the main functions are loaded
 
-;; Helper predicate to check if we are in a chatgpt-shell buffer
 (defun chatgpt-shell-transient--in-shell-p ()
   "Return non-nil if the current buffer is in chatgpt-shell-mode."
   (derived-mode-p 'chatgpt-shell-mode))
@@ -22,15 +21,11 @@
    ["Core Shell & Compose"
     ("s" "Focus/Start Shell" chatgpt-shell)
     ("N" "Start New Shell" (lambda () (interactive) (chatgpt-shell t)))
-    ;; Removed C and K from here - they are conditional below
     ("e" "Compose Prompt" chatgpt-shell-prompt-compose)
     ("p" "Prompt (minibuffer)"
      (lambda ()
        (interactive)
-       ;; Quit transient first
        (transient-quit-one)
-       ;; Schedule the actual prompt function to run shortly after,
-       ;; allowing this lambda to return immediately.
        (run-with-idle-timer 0 nil #'chatgpt-shell-prompt)))
     ("P" "Prompt (append kill)"
      (lambda ()
@@ -58,7 +53,6 @@
    "Shell Context Actions"
    ["Shell Buffer Management"
     ("C" "Clear Shell Buffer" chatgpt-shell-clear-buffer :if chatgpt-shell-transient--in-shell-p)
-    ;; Changed K to I to avoid conflict and keep K for Previous Source Block
     ("I" "Interrupt Request" chatgpt-shell-interrupt :if chatgpt-shell-transient--in-shell-p)]
 
    ["Shell Navigation"
@@ -92,12 +86,10 @@
     ("L" "Reload Default Models" chatgpt-shell-reload-default-models)]
 
    ["Other"
-    ;; Restore doesn't depend on the *current* buffer being a shell
     ("v" "Show Version" chatgpt-shell-version)]
    ]
   )
 
-;; Define the suffix command (optional, but keeps the main definition cleaner)
 (transient-define-suffix chatgpt-shell-transient--popup--suffix ()
   :description "ChatGPT Shell Transient Suffix"
   :class 'transient-suffix)
@@ -107,7 +99,6 @@
 (defun chatgpt-shell-transient ()
   "Invoke the main transient menu for chatgpt-shell."
   (interactive)
-  ;; Call the correctly named transient prefix command
   (chatgpt-shell-transient--popup))
 
 (provide 'chatgpt-shell-transient)

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -15,81 +15,82 @@
 (transient-define-prefix chatgpt-shell-transient--popup ()
   "Transient menu for chatgpt-shell commands."
   :transient-suffix 'chatgpt-shell-transient--popup--suffix
-  [ ;; Group 1: Always available core actions
-   "ChatGPT Shell actions"
-   ["Core Shell & Compose"
-    ("s" "Focus/Start Shell" chatgpt-shell)
-    ("N" "Start New Shell" (lambda () (interactive) (chatgpt-shell t)))
-    ("e" "Compose Prompt" chatgpt-shell-prompt-compose)
-    ("p" "Prompt (minibuffer)"
+  :transient-non-suffix 'transient--do-stay
+  [ ;; Row 1: Always available core actions
+   ["Shells"
+    ("b" "Switch to shell buffer" chatgpt-shell)
+    ("N" "Create new shell" (lambda () (interactive) (chatgpt-shell t)))]
+
+   ["Compose prompt via"
+    ("e" "Dedicated buffer" chatgpt-shell-prompt-compose)
+    ("p" "Minibuffer"
      (lambda ()
        (interactive)
        (transient-quit-one)
        (run-with-idle-timer 0 nil #'chatgpt-shell-prompt)))
-    ("P" "Prompt (append kill)"
+    ("P" "Minibuffer (include last kill)"
      (lambda ()
        (interactive)
        (transient-quit-one)
-       (run-with-idle-timer 0 nil #'chatgpt-shell-prompt-appending-kill-ring)))
-     ("q" "Quick Insert"
-      (lambda ()
-        (interactive)
-        (transient-quit-one)
-        (run-with-idle-timer 0 nil #'chatgpt-shell-quick-insert)))]
+       (run-with-idle-timer 0 nil #'chatgpt-shell-prompt-appending-kill-ring)))]
 
-   ;; Group 2: Region-specific actions (available if region is active)
-   ["Region Actions"
-    ("r" "Send Region" (lambda () (interactive) (chatgpt-shell-send-region nil)) :if region-active-p)
-    ("R" "Send & Review Region" chatgpt-shell-send-and-review-region :if region-active-p)
-    ("d" "Describe Code" chatgpt-shell-describe-code :if region-active-p)
-    ("f" "Refactor Code" chatgpt-shell-refactor-code :if region-active-p)
-    ("g" "Write Git Commit" chatgpt-shell-write-git-commit :if region-active-p)
-    ("t" "Generate Unit Test" chatgpt-shell-generate-unit-test :if region-active-p)
-    ("w" "Proofread Region" chatgpt-shell-proofread-region :if region-active-p)]
+   ["Inline edit"
+    ("q" "Quick insert/edit"
+     (lambda ()
+       (interactive)
+       (transient-quit-one)
+       (run-with-idle-timer 0 nil #'chatgpt-shell-quick-insert)))
+    ("r" "Send region" (lambda () (interactive) (chatgpt-shell-send-region nil)) :if region-active-p)
+    ("R" "Send & review region" chatgpt-shell-send-and-review-region :if region-active-p)]
    ]
 
-  [ ;; Group 3: Shell-specific actions (available only in chatgpt-shell buffer)
-   "Shell Context Actions"
-   ["Shell Buffer Management"
-    ("C" "Clear Shell Buffer" chatgpt-shell-clear-buffer :if chatgpt-shell-transient--in-shell-p)
-    ("I" "Interrupt Request" chatgpt-shell-interrupt :if chatgpt-shell-transient--in-shell-p)]
+  [ ;; Row 2: Session management and navigation
+   ["Session"
+    ("m" "Swap model" chatgpt-shell-swap-model :if chatgpt-shell-transient--in-shell-p)
+    ("L" "Reload models" chatgpt-shell-reload-default-models)
+    ("y" "Swap system prompt" chatgpt-shell-swap-system-prompt :if chatgpt-shell-transient--in-shell-p)]
 
-   ["Shell Navigation"
-    ("h" "Search History"
+   ["History"
+    ("h" "Search"
      (lambda ()
        (interactive)
        (transient-quit-one)
-       (run-with-idle-timer 0 nil #'chatgpt-shell-search-history)) :if chatgpt-shell-transient--in-shell-p)
-    ("j" "Next Item" chatgpt-shell-next-item :if chatgpt-shell-transient--in-shell-p)
-    ("k" "Previous Item" chatgpt-shell-previous-item :if chatgpt-shell-transient--in-shell-p)
-    ("J" "Next Source Block" chatgpt-shell-next-source-block :if chatgpt-shell-transient--in-shell-p)
-    ("K" "Previous Source Block" chatgpt-shell-previous-source-block :if chatgpt-shell-transient--in-shell-p)]
+       (run-with-idle-timer 0 nil #'chatgpt-shell-search-history)) :if chatgpt-shell-transient--in-shell-p)]
 
-   ["Block Actions"
-    ("x" "Execute Block" chatgpt-shell-execute-babel-block-action-at-point :if chatgpt-shell-transient--in-shell-p)
-    ("E" "Edit Block" chatgpt-shell-edit-block-at-point :if chatgpt-shell-transient--in-shell-p)
-    ("V" "View Block" chatgpt-shell-view-block-at-point :if chatgpt-shell-transient--in-shell-p)]
+   ["Navigation"
+    ("n" "Next item" chatgpt-shell-next-item :if chatgpt-shell-transient--in-shell-p :transient t)
+    ("p" "Previous item" chatgpt-shell-previous-item :if chatgpt-shell-transient--in-shell-p :transient t)
+    ("TAB" "Next source block" chatgpt-shell-next-source-block :if chatgpt-shell-transient--in-shell-p :transient t)
+    ("<backtab>" "Previous source block" chatgpt-shell-previous-source-block :if chatgpt-shell-transient--in-shell-p :transient t)]
+   ]
 
-   ["Shell Configuration"
-    ("m" "Swap Model" chatgpt-shell-swap-model :if chatgpt-shell-transient--in-shell-p)
-    ("y" "Swap System Prompt" chatgpt-shell-swap-system-prompt :if chatgpt-shell-transient--in-shell-p)]
+  [ ;; Row 3: Source blocks, transcript, and code actions
+   ["Source blocks"
+    ("C-c C-c" "Execute" chatgpt-shell-execute-babel-block-action-at-point :if chatgpt-shell-transient--in-shell-p)
+    ("E" "Edit" chatgpt-shell-edit-block-at-point :if chatgpt-shell-transient--in-shell-p)
+    ("V" "View" chatgpt-shell-view-block-at-point :if chatgpt-shell-transient--in-shell-p)]
 
-   ["Shell Session"
-    ("S" "Save Transcript"
+   ["Transcript"
+    ("S" "Save"
      (lambda ()
        (interactive)
        (transient-quit-one)
        (run-with-idle-timer 0 nil #'chatgpt-shell-save-session-transcript)) :if chatgpt-shell-transient--in-shell-p)
-    ("O" "Restore Transcript" chatgpt-shell-restore-session-from-transcript :if chatgpt-shell-transient--in-shell-p)]
+    ("O" "Restore" chatgpt-shell-restore-session-from-transcript :if chatgpt-shell-transient--in-shell-p)]
+
+   ["Code Actions"
+    ("d" "Describe code" chatgpt-shell-describe-code :if region-active-p)
+    ("f" "Refactor code" chatgpt-shell-refactor-code :if region-active-p)
+    ("g" "Write git commit" chatgpt-shell-write-git-commit :if region-active-p)
+    ("t" "Generate unit test" chatgpt-shell-generate-unit-test :if region-active-p)
+    ("w" "Proofread" chatgpt-shell-proofread-paragraph-or-region :if region-active-p)]
    ]
 
-  [ ;; Group 4: General utilities (mostly always available)
-   "Configuration & Utilities"
-   ["Model & Configuration"
-    ("L" "Reload Default Models" chatgpt-shell-reload-default-models)]
-
+  [ ;; Row 4: Utilities and other actions
    ["Other"
-    ("v" "Show Version" chatgpt-shell-version)]
+    ("C" "Clear buffer" chatgpt-shell-clear-buffer :if chatgpt-shell-transient--in-shell-p)
+    ("I" "Interrupt" chatgpt-shell-interrupt :if chatgpt-shell-transient--in-shell-p)
+    ("v" "Show version" chatgpt-shell-version)]
    ]
   )
 

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -8,57 +8,99 @@
 (require 'transient)
 (require 'chatgpt-shell) ;; Ensure the main functions are loaded
 
+;; Helper predicate to check if we are in a chatgpt-shell buffer
+(defun chatgpt-shell-transient--in-shell-p ()
+  "Return non-nil if the current buffer is in chatgpt-shell-mode."
+  (derived-mode-p 'chatgpt-shell-mode))
+
 ;;;###autoload
 (transient-define-prefix chatgpt-shell-transient--popup ()
   "Transient menu for chatgpt-shell commands."
-  [
+  :transient-suffix 'chatgpt-shell-transient--popup--suffix
+  [ ;; Group 1: Always available core actions
    "ChatGPT Shell actions"
    ["Core Shell & Compose"
     ("s" "Focus/Start Shell" chatgpt-shell)
     ("N" "Start New Shell" (lambda () (interactive) (chatgpt-shell t)))
-     ("C" "Clear Shell Buffer" chatgpt-shell-clear-buffer)
-     ("K" "Interrupt Request" chatgpt-shell-interrupt)
-     ("e" "Compose Prompt" chatgpt-shell-prompt-compose)
-     ("p" "Prompt (minibuffer)" chatgpt-shell-prompt)
-     ("P" "Prompt (append kill)" chatgpt-shell-prompt-appending-kill-ring)
-     ("q" "Quick Insert" chatgpt-shell-quick-insert)]
+    ;; Removed C and K from here - they are conditional below
+    ("e" "Compose Prompt" chatgpt-shell-prompt-compose)
+    ("p" "Prompt (minibuffer)"
+     (lambda ()
+       (interactive)
+       ;; Quit transient first
+       (transient-quit-one)
+       ;; Schedule the actual prompt function to run shortly after,
+       ;; allowing this lambda to return immediately.
+       (run-with-idle-timer 0 nil #'chatgpt-shell-prompt)))
+    ("P" "Prompt (append kill)"
+     (lambda ()
+       (interactive)
+       (transient-quit-one)
+       (run-with-idle-timer 0 nil #'chatgpt-shell-prompt-appending-kill-ring)))
+     ("q" "Quick Insert"
+      (lambda ()
+        (interactive)
+        (transient-quit-one)
+        (run-with-idle-timer 0 nil #'chatgpt-shell-quick-insert)))]
 
-    ["Region Actions"
-     ("r" "Send Region" (lambda () (interactive) (chatgpt-shell-send-region nil)))
-     ("R" "Send & Review Region" chatgpt-shell-send-and-review-region)
-     ("d" "Describe Code" chatgpt-shell-describe-code)
-     ("f" "Refactor Code" chatgpt-shell-refactor-code)
-     ("g" "Write Git Commit" chatgpt-shell-write-git-commit)
-     ("t" "Generate Unit Test" chatgpt-shell-generate-unit-test)
-     ("w" "Proofread Region" chatgpt-shell-proofread-region)]
+   ;; Group 2: Region-specific actions (available if region is active)
+   ["Region Actions"
+    ("r" "Send Region" (lambda () (interactive) (chatgpt-shell-send-region nil)) :if region-active-p)
+    ("R" "Send & Review Region" chatgpt-shell-send-and-review-region :if region-active-p)
+    ("d" "Describe Code" chatgpt-shell-describe-code :if region-active-p)
+    ("f" "Refactor Code" chatgpt-shell-refactor-code :if region-active-p)
+    ("g" "Write Git Commit" chatgpt-shell-write-git-commit :if region-active-p)
+    ("t" "Generate Unit Test" chatgpt-shell-generate-unit-test :if region-active-p)
+    ("w" "Proofread Region" chatgpt-shell-proofread-region :if region-active-p)]
+   ]
+
+  [ ;; Group 3: Shell-specific actions (available only in chatgpt-shell buffer)
+   "Shell Context Actions"
+   ["Shell Buffer Management"
+    ("C" "Clear Shell Buffer" chatgpt-shell-clear-buffer :if chatgpt-shell-transient--in-shell-p)
+    ;; Changed K to I to avoid conflict and keep K for Previous Source Block
+    ("I" "Interrupt Request" chatgpt-shell-interrupt :if chatgpt-shell-transient--in-shell-p)]
 
    ["Shell Navigation"
-    ("h" "Search History" chatgpt-shell-search-history)
-    ("j" "Next Item" chatgpt-shell-next-item)
-    ("k" "Previous Item" chatgpt-shell-previous-item)
-     ("J" "Next Source Block" chatgpt-shell-next-source-block)
-     ("K" "Previous Source Block" chatgpt-shell-previous-source-block)]
+    ("h" "Search History" chatgpt-shell-search-history :if chatgpt-shell-transient--in-shell-p)
+    ("j" "Next Item" chatgpt-shell-next-item :if chatgpt-shell-transient--in-shell-p)
+    ("k" "Previous Item" chatgpt-shell-previous-item :if chatgpt-shell-transient--in-shell-p)
+    ("J" "Next Source Block" chatgpt-shell-next-source-block :if chatgpt-shell-transient--in-shell-p)
+    ("K" "Previous Source Block" chatgpt-shell-previous-source-block :if chatgpt-shell-transient--in-shell-p)]
 
-    ["Block Actions"
-     ("x" "Execute Block" chatgpt-shell-execute-babel-block-action-at-point)
-     ("E" "Edit Block" chatgpt-shell-edit-block-at-point)
-     ("V" "View Block" chatgpt-shell-view-block-at-point)]
+   ["Block Actions"
+    ("x" "Execute Block" chatgpt-shell-execute-babel-block-action-at-point :if chatgpt-shell-transient--in-shell-p)
+    ("E" "Edit Block" chatgpt-shell-edit-block-at-point :if chatgpt-shell-transient--in-shell-p)
+    ("V" "View Block" chatgpt-shell-view-block-at-point :if chatgpt-shell-transient--in-shell-p)]
+
+   ["Shell Configuration"
+    ("m" "Swap Model" chatgpt-shell-swap-model :if chatgpt-shell-transient--in-shell-p)
+    ("y" "Swap System Prompt" chatgpt-shell-swap-system-prompt :if chatgpt-shell-transient--in-shell-p)]
+
+   ["Shell Session"
+    ("S" "Save Transcript"
+     (lambda ()
+       (interactive)
+       (transient-quit-one)
+       (run-with-idle-timer 0 nil #'chatgpt-shell-save-session-transcript)) :if chatgpt-shell-transient--in-shell-p)
+    ("O" "Restore Transcript" chatgpt-shell-restore-session-from-transcript :if chatgpt-shell-transient--in-shell-p)]
    ]
 
-  [
+  [ ;; Group 4: General utilities (mostly always available)
    "Configuration & Utilities"
    ["Model & Configuration"
-    ("m" "Swap Model" chatgpt-shell-swap-model)
-    ("y" "Swap System Prompt" chatgpt-shell-swap-system-prompt)
-     ("L" "Reload Default Models" chatgpt-shell-reload-default-models)]
+    ("L" "Reload Default Models" chatgpt-shell-reload-default-models)]
 
-    ["Session & Other"
-     ("S" "Save Transcript" chatgpt-shell-save-session-transcript)
-     ("O" "Restore Transcript" chatgpt-shell-restore-session-from-transcript)
-     ("i" "Describe Image" chatgpt-shell-describe-image)
-     ("v" "Show Version" chatgpt-shell-version)]
+   ["Other"
+    ;; Restore doesn't depend on the *current* buffer being a shell
+    ("v" "Show Version" chatgpt-shell-version)]
    ]
   )
+
+;; Define the suffix command (optional, but keeps the main definition cleaner)
+(transient-define-suffix chatgpt-shell-transient--popup--suffix ()
+  :description "ChatGPT Shell Transient Suffix"
+  :class 'transient-suffix)
 
 
 ;;;###autoload

--- a/chatgpt-shell-transient.el
+++ b/chatgpt-shell-transient.el
@@ -6,7 +6,6 @@
 ;;; Code:
 
 (require 'transient)
-(require 'chatgpt-shell) ;; Ensure the main functions are loaded
 
 (defun chatgpt-shell-transient--in-shell-p ()
   "Return non-nil if the current buffer is in chatgpt-shell-mode."

--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -5,7 +5,7 @@
 ;; Author: Alvaro Ramirez https://xenodium.com
 ;; URL: https://github.com/xenodium/chatgpt-shell
 ;; Version: 2.16.4
-;; Package-Requires: ((emacs "28.1") (shell-maker "0.76.3"))
+;; Package-Requires: ((emacs "28.1") (shell-maker "0.76.3") (transient "0.4.0"))
 (defconst chatgpt-shell--version "2.16.4")
 
 ;; This package is free software; you can redistribute it and/or modify
@@ -84,6 +84,7 @@
 (require 'chatgpt-shell-openrouter)
 (require 'chatgpt-shell-perplexity)
 (require 'chatgpt-shell-prompt-compose)
+(require 'chatgpt-shell-transient)
 
 (defcustom chatgpt-shell-request-timeout 600
   "How long to wait for a request to time out in seconds."
@@ -822,6 +823,8 @@ Set SYSTEM-PROMPT to override variable `chatgpt-shell-system-prompt'"
       #'chatgpt-shell-next-item)
     (define-key chatgpt-shell-mode-map (kbd "C-c C-e")
       #'chatgpt-shell-prompt-compose)
+    (define-key chatgpt-shell-mode-map (kbd "C-c C-t")
+      #'chatgpt-shell-transient)
     shell-buffer))
 
 (defun chatgpt-shell--shrink-system-prompt (prompt)


### PR DESCRIPTION
Closes #341 

Here's the new transient menu!

How it looks **outside** the chatgpt-shell buffer:

![image](https://github.com/user-attachments/assets/1390a991-bc51-4545-ac00-59bc9d3c2885)

How it looks in the `chatgpt-shell` buffer (`C-c C-t` by default):

![image](https://github.com/user-attachments/assets/bdd76ea5-4c4c-4e4d-826c-e66a257d9e27)

How it looks on region selection:

![image](https://github.com/user-attachments/assets/edd532d4-0b4b-4642-ac94-9791efb19a68)

Some videos:

General demo:

https://github.com/user-attachments/assets/7bf30c6f-b248-4033-a564-bcbd5d83c9dc



Region selection demo:

https://github.com/user-attachments/assets/b37f71f2-edb3-467d-b49b-d87d0fc151d9



