### PR TITLE
Transform chatgpt-shell-proofread-region to a DWIM approach

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1469,11 +1469,22 @@ If region is active, append to prompt."
 
 ;;;###autoload
 (defun chatgpt-shell-proofread-region ()
-  "Proofread text from region using ChatGPT.
+  "Proofread text from region or current paragraph using ChatGPT.
 
 See `chatgpt-shell-prompt-header-proofread-region' to change prompt or language."
   (interactive)
-  (let* ((region (chatgpt-shell--region))
+  (let* ((region (if (use-region-p)
+                     (chatgpt-shell--region)
+                   (save-excursion
+                     (mark-paragraph)
+                     ;; Adjust end to avoid including the newline character after the paragraph
+                     (let ((start (region-beginning))
+                           (end (progn (goto-char (region-end))
+                                       (skip-chars-backward "\n")
+                                       (point))))
+                       (list (cons :start start)
+                             (cons :end end)
+                             (cons :text (buffer-substring-no-properties start end)))))))
          (query (map-elt region :text))
          (context nil))
     (chatgpt-shell-request-and-insert-merged-response


### PR DESCRIPTION
Thanks for your package.

Here is a small tweak to `chatgpt-shell-proofread-region` to decrease friction: if no region is active, mark paragraph and proofread this paragraph. Since this function is likely to be run paragraph by paragraph, this removes the need for selecting a paragraph.