### PR TITLE
Rename proofread function, and add alias for old name

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -189,6 +189,8 @@ For example:
 
 (defalias 'chatgpt-shell-save-session-transcript #'shell-maker-save-session-transcript)
 
+(defalias 'chatgpt-shell-proofread-region #'chatgpt-shell-proofread-paragraph-or-region)
+
 (defvar chatgpt-shell--prompt-history nil)
 
 (defcustom chatgpt-shell-language-mapping '(("elisp" . "emacs-lisp")
@@ -1468,7 +1470,7 @@ If region is active, append to prompt."
   (chatgpt-shell-send-region-with-header chatgpt-shell-prompt-header-generate-unit-test))
 
 ;;;###autoload
-(defun chatgpt-shell-proofread-region ()
+(defun chatgpt-shell-proofread-paragraph-or-region ()
   "Proofread text from region or current paragraph using ChatGPT.
 
 See `chatgpt-shell-prompt-header-proofread-region' to change prompt or language."


### PR DESCRIPTION
You are right. It is useful to rename the function. Here is the PR.

Thanks for merging so quickly.

Note that there is one tiny default to what I proposed. When proofreading a paragraph, if the AI suggestion is rejected, instead of the point staying at its original position, the point is moved to the beginning of the paragraph and the paragraph is marked. I have tried a few things, but I was not able to solve this, but this is a minor issue that I can live with.