### PR TITLE
Update shell-maker install instructions in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -125,7 +125,7 @@ Via [[https://github.com/jwiegley/use-package][use-package]], you can install wi
 
 #+begin_src emacs-lisp :lexical no
   (use-package shell-maker
-    :straight (:type git :host github :repo "xenodium/shell-maker" :files ("shell-maker*.el")))
+    :straight (:type git :host github :repo "xenodium/shell-maker" :files ("*.el")))
 
   (use-package chatgpt-shell
     :straight (:type git :host github :repo "xenodium/chatgpt-shell" :files ("chatgpt-shell*.el"))

--- a/README.org
+++ b/README.org
@@ -125,7 +125,7 @@ Via [[https://github.com/jwiegley/use-package][use-package]], you can install wi
 
 #+begin_src emacs-lisp :lexical no
   (use-package shell-maker
-    :straight (:type git :host github :repo "xenodium/shell-maker" :files ("*.el")))
+    :straight (:type git :host github :repo "xenodium/shell-maker"))
 
   (use-package chatgpt-shell
     :straight (:type git :host github :repo "xenodium/chatgpt-shell" :files ("chatgpt-shell*.el"))


### PR DESCRIPTION
**Now that this file exists:**
https://github.com/xenodium/shell-maker/blob/main/markdown-overlays.el

The instructions that only include the `shell-maker.el` file are insufficient to actually install the whole package. As currently written - running `chatgpt-shell` yields the following error:

```
Please update 'shell-maker' to v0.77.1 or newer
```

**Other thought:**
You may want to change the name of the `markdown-overlays.el` file such that it's namespaced like `shell-maker-markdown-overlays` - in which case, the current instructions and the files remain explicit. That's, of course, up to you!


**Addendum:**
Thanks for an amazing blog and a million awesome packages.

I love your work 🎉 