### PR TITLE
fix: Foreign buffer fontification (fixes #375)

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -707,7 +707,8 @@ See `shell-maker-welcome-message' as an example."
        (error "%s not found" (chatgpt-shell-model-version))))
    :on-command-finished
    (lambda (command output success)
-     (markdown-overlays-put)
+     (with-current-buffer (chatgpt-shell--primary-buffer)
+       (markdown-overlays-put))
      (run-hook-with-args 'chatgpt-shell-after-command-functions
                          command output success))
    :redact-log-output


### PR DESCRIPTION
Fix fontification of arbitrary buffers. Currently, with streaming enabled, it is possible to switch away from the chatgpt-shell buffer while it is finishing writing the response. Once this happened the `on-command-finished` puts markdown overlays in the current buffer, which might not be the chatgpt-shell buffer.

Wrap markdown overlay fontification in
`(with-current-buffer (chatgpt-shell--primary-buffer))` s.t. it puts the overlays in the `chatgpt-shell` buffer.