### PR TITLE
Add Gemini 2.5 (Flash & Pro) models and update Qwen to Qwen3 in OpenRouter provider

### DIFF
--- a/chatgpt-shell-openrouter.el
+++ b/chatgpt-shell-openrouter.el
@@ -102,20 +102,20 @@ VALIDATE-COMMAND and OTHER-PARAMS for `chatgpt-shell-openai-make-model'."
          :validate-command #'chatgpt-shell-validate-no-system-prompt
          :other-params '((provider (require_parameters . t))))
         (chatgpt-shell-openrouter-make-model
-         :version "qwen/qwen-2.5-coder-32b-instruct"
-         :short-version "qwen-2.5-coder-32b"
+         :version "qwen/qwen3-coder"
+         :short-version "qwen3-coder"
          :label "Qwen"
          :token-width 16
-         ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
-         :context-window 33000
+         ;; See https://openrouter.ai/qwen/qwen3-coder
+         :context-window 262144
          ;; Multiple quantizations are offered for this model by different
          ;; providers so we restrict to one for consistency. Note that the sense
          ;; in which provider is used here means the providers available through
          ;; OpenRouter. This is different from the meaning of the :provider
          ;; argument.
          ;;
-         ;; See https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct
-         :other-params '((provider (quantizations . ["bf16"]))))
+         ;; See https://openrouter.ai/qwen/qwen3-coder
+         :other-params '((provider (quantizations . ["fp4"]))))
         (chatgpt-shell-openrouter-make-model
          :version "anthropic/claude-3.7-sonnet"
          :short-version "claude-3.7-sonnet"


### PR DESCRIPTION
## Description
This PR introduces two new Gemini models (Gemini 2.5 Flash and Gemini 2.5 Pro) to the available models list within `chatgpt-shell-openrouter.el`.

Additionally, the Qwen model configuration has been updated to reflect:
- A new version string: "qwen/qwen3-coder" (formerly "qwen/qwen-2.5-coder-32b-instruct").
- An expanded context window: 262144 (formerly 33000).
- An updated quantization: "fp4" (formerly "bf16").

These changes aim to enhance the model offerings and ensure compatibility with the latest Qwen model on OpenRouter.

## How Has This Been Tested?
The changes were tested by locally enabling the `chatgpt-shell-openrouter` package and verifying that:
* The newly added Gemini 2.5 Flash and Gemini 2.5 Pro models appear in the model selection list.
* The updated Qwen model (Qwen3-coder) is correctly configured and functional.
* API calls to these models through OpenRouter are successful and responses are received as expected.

