### PR TITLE
Adjust the marking of paragraphs in chatgpt-shell-proofread-paragraph-or-region

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -1415,9 +1415,15 @@ See `chatgpt-shell-prompt-header-proofread-region' to change prompt or language.
   (let* ((region (if (use-region-p)
                      (chatgpt-shell--region)
                    (save-excursion
-                     (mark-paragraph)
-                     ;; Adjust end to avoid including the newline character after the paragraph
-                     (let ((start (region-beginning))
+		     ;; Mark the current paragraph or org element, because org
+		     ;; defines paragraphs differently from other text modes
+                     (if (derived-mode-p 'org-mode)
+			 (org-mark-element)
+		       (mark-paragraph))
+                     ;; Adjust start and end to avoid including newline characters
+                     (let ((start (progn (goto-char (region-beginning))
+					 (skip-chars-forward "\n")
+					 (point)))
                            (end (progn (goto-char (region-end))
                                        (skip-chars-backward "\n")
                                        (point))))


### PR DESCRIPTION
Hi,

This is a follow-up of #352. It fixes a limit of the `mark-paragraph` function. `mark-paragraph` marks a paragraph including the previous empty line (probably to facilitate cutting and pasting paragraphs). When a paragraph marked like this is proofread, the LLM usually strips the empty line, which has to be added back. This PR strips the empty lines from the marked region to avoid this step.

While preparing the PR, I have also realized that the function was not working as expected in bullet points in org mode. In LaTeX and markdown modes, using `mark-paragraph` on a bullet point marks the current bullet point. Not in org mode. In org mode, `mark-paragraph` marks the first real paragraph after the bullet point. To avoid this behavior, I have used the function `org-mark-element` when in org mode. However, there is one side effect of using this function. If the point is on an org section heading, the whole section would be marked, not just the title. Anyway, in the current version, if the point is on an section heading, this is the following paragraph that is marked, so this is not the expected behavior anyway.