### PR TITLE
Feature: add chatgpt-shell-before-command-functions hook

### DIFF
--- a/chatgpt-shell.el
+++ b/chatgpt-shell.el
@@ -169,14 +169,13 @@ Note: in all cases responses are written to the shell to keep context."
   "Abnormal hook (i.e. with parameters) invoked before each command.
 
 This is useful if you'd like to automatically handle or suggest things
-post execution.
+prior to execution.
 
 For example:
 
 \(add-hook `chatgpt-shell-before-command-functions'
-   (lambda (command output success)
-     (message \"Command: %s\" command)
-     (message \"Output: %s\" output)))"
+   (lambda (command)
+     (message \"Command: %s\" command)))"
   :type 'hook
   :group 'shell-maker)
 


### PR DESCRIPTION
# Use case:

I’m using chatgpt-shell as part of a larger system where I sometimes want to log commands externally or selectively route content into a local knowledge graph.

To do this cleanly, I’ve been maintaining a small local patch that introduces a “before command” hook that is exactly "symmetrical" with `chatgpt-shell-after-command-functions'.

# New feature

> `chatgpt-shell-before-command-functions` [...] This is useful if you'd like to automatically handle or suggest things
prior to execution.

# Example usage

I'm using it to *programmatically* reset the system prompt with each call, here's a reduced example:

```elisp
(defun set-user-system-prompt (_command)
  (let* ((now   (current-time))
         (date  (format-time-string "%A, %B %d, %Y" now))
         (time  (format-time-string "%H:%M" now))
         (prompt (concat
                  "You use markdown liberally to structure responses. "
                  "Always show code snippets in markdown blocks with language labels. "
                  "The user’s most recent query has been submitted at the following date: "
                  date " and the local time (in the London timezone) is " time
                  ". Please preface all your replies with the metadata ["
                  date "/" time "].\n")))
    (setq chatgpt-shell-system-prompts
          `(("tl;dr"  . "Be as succinct but informative as possible and respond in tl;dr form to my queries")
            ("General" . ,prompt)))))

(add-hook 'chatgpt-shell-before-command-functions #'set-user-system-prompt)
```