### PR TITLE
Add the 3.0 flash preview

### DIFF
--- a/chatgpt-shell-google.el
+++ b/chatgpt-shell-google.el
@@ -262,8 +262,14 @@ Returns the new boolean value of `:grounding-search'."
                                          :path "/v1beta/models/gemini-3-pro-preview"
                                          :grounding-search t
                                          :url-context t
-                                         :thinking-budget-min 1
-                                         :thinking-budget-max 65535
+                                         :reasoning-effort-selector #'chatgpt-shell-google-reasoning-effort-selector
+                                         :token-width 4
+                                         :context-window 1048576)
+        (chatgpt-shell-google-make-model :version "gemini-3-flash-preview"
+                                         :short-version "gemini-3-flash-preview"
+                                         :path "/v1beta/models/gemini-3-flash-preview"
+                                         :grounding-search t
+                                         :url-context t
                                          :reasoning-effort-selector #'chatgpt-shell-google-reasoning-effort-selector
                                          :token-width 4
                                          :context-window 1048576)


### PR DESCRIPTION
Google just release the 3.0 flash this morning. Add it in this PR

**Some changes**

According to this ([link](https://ai.google.dev/gemini-api/docs/gemini-3)): 

>Important: You cannot use both thinking_level and the legacy thinking_budget parameter in the same request. Doing so will return a 400 error.

I removed the thinking_budget in 3.0 models. We may need the `thinking_level` for 3.0 models in future. 