### PR TITLE
Update Anthropic models

### DIFF
--- a/chatgpt-shell-anthropic.el
+++ b/chatgpt-shell-anthropic.el
@@ -150,6 +150,13 @@ REASONING-EFFORT-SELECTOR."
    ;; A token is equivalent to _about_ 4 characters.
    ;;
    ;; claude-4-sonnet-latest and claude-4-sonnet-latest are not supported yet.
+   (chatgpt-shell-anthropic--make-model :version "claude-opus-4-6"
+                                        :short-version "opus-4.6"
+                                        :token-width  4
+                                        :thinking-budget-min 1024
+                                        :reasoning-effort-selector #'chatgpt-shell-anthropic-reasoning-effort-selector
+                                        :max-tokens 32000
+                                        :context-window 200000)
    (chatgpt-shell-anthropic--make-model :version "claude-opus-4-5"
                                         :short-version "opus-4.5"
                                         :token-width  4
@@ -170,6 +177,13 @@ REASONING-EFFORT-SELECTOR."
                                         :thinking-budget-min 1024
                                         :reasoning-effort-selector #'chatgpt-shell-anthropic-reasoning-effort-selector
                                         :max-tokens 32000
+                                        :context-window 200000)
+   (chatgpt-shell-anthropic--make-model :version "claude-sonnet-4-6"
+                                        :short-version "sonnet-4.6"
+                                        :token-width  4
+                                        :thinking-budget-min 1024
+                                        :reasoning-effort-selector #'chatgpt-shell-anthropic-reasoning-effort-selector
+                                        :max-tokens 64000
                                         :context-window 200000)
    (chatgpt-shell-anthropic--make-model :version "claude-sonnet-4-5"
                                         :short-version "sonnet-4.5"

--- a/chatgpt-shell-anthropic.el
+++ b/chatgpt-shell-anthropic.el
@@ -185,32 +185,10 @@ REASONING-EFFORT-SELECTOR."
                                         :reasoning-effort-selector #'chatgpt-shell-anthropic-reasoning-effort-selector
                                         :max-tokens 64000
                                         :context-window 200000)
-   (chatgpt-shell-anthropic--make-model :version "claude-3-7-sonnet-latest"
-                                        :short-version "3.7-sonnet"
-                                        :token-width  4
-                                        :thinking-budget-min 1024
-                                        :reasoning-effort-selector #'chatgpt-shell-anthropic-reasoning-effort-selector
-                                        :max-tokens 64000
-                                        :context-window 200000)
-   (chatgpt-shell-anthropic--make-model :version "claude-3-5-sonnet-latest"
-                                        :short-version "3.5-sonnet"
-                                        :token-width  4
-                                        :max-tokens 8192
-                                        :context-window 200000)
    (chatgpt-shell-anthropic--make-model :version "claude-haiku-4-5-20251001"
                                         :short-version "haiku-4.5"
                                         :token-width  4
                                         :max-tokens 64000
-                                        :context-window 200000)
-   (chatgpt-shell-anthropic--make-model :version "claude-3-5-haiku-latest"
-                                        :short-version "3.5-haiku"
-                                        :token-width  4
-                                        :max-tokens 8192
-                                        :context-window 200000)
-   (chatgpt-shell-anthropic--make-model :version "claude-3-opus-latest"
-                                        :short-version "3-opus"
-                                        :token-width  4
-                                        :max-tokens 4096
                                         :context-window 200000)))
 
 (cl-defun chatgpt-shell-anthropic--make-url (&key _command model _settings)


### PR DESCRIPTION
Since the last update several Anthropic models got released or retired. 
Update the list of models accordingly:

Removals:
https://platform.claude.com/docs/en/about-claude/model-deprecations

Current Models:
https://platform.claude.com/docs/en/about-claude/models/overview#model-comparison-table

Note that Anthropic now allows a context window of 1M with a special
`context-1m-2025-08-07` header for the new Opus 4.6 and Sonnet 4.6
models. This is unsupported here. We still stick to the default 200K
context window.